### PR TITLE
Add web page to load best ball rankings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# bestballranks
+# Best Ball Rankings
+
+This repository contains a simple web page that pulls fantasy football rankings
+and sentiment scores from a Google Spreadsheet. The data is loaded directly in
+the browser and displayed in a table.
+
+## Usage
+
+Open `index.html` in a modern web browser. The page will fetch data from the
+public spreadsheet and populate the table with the following columns:
+
+- **Ranking**
+- **Position**
+- **Team**
+- **Player**
+- **Sentiment** (from the `Sentiment` sheet, column F)
+
+The spreadsheet ID and sheet names are configured directly in `index.html`.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Best Ball Rankings</title>
+  <style>
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border: 1px solid #ddd; padding: 8px; }
+    th { background-color: #f2f2f2; }
+  </style>
+</head>
+<body>
+  <h1>Best Ball Rankings</h1>
+  <table id="rankings-table">
+    <thead>
+      <tr>
+        <th>Ranking</th>
+        <th>Position</th>
+        <th>Team</th>
+        <th>Player</th>
+        <th>Sentiment</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+  <script>
+    const sheetId = '1rNouBdE-HbWafu-shO_5JLPSrLhr-xuGpXYfyOI-2oY';
+    const rankingsUrl = `https://opensheet.elk.sh/${sheetId}/Rankings`;
+    const sentimentUrl = `https://opensheet.elk.sh/${sheetId}/Sentiment`;
+
+    async function loadData() {
+      try {
+        const [rankingsRes, sentimentRes] = await Promise.all([
+          fetch(rankingsUrl),
+          fetch(sentimentUrl)
+        ]);
+        const rankings = await rankingsRes.json();
+        const sentiment = await sentimentRes.json();
+
+        const sentimentMap = {};
+        sentiment.forEach(row => {
+          // Sentiment score is stored in column F on the Sentiment tab.
+          // opensheet.elk.sh uses header names; if not present use 'F'.
+          const player = row.Player || row.player;
+          const score = row.Sentiment || row['Sentiment Score'] || row.F;
+          sentimentMap[player] = score;
+        });
+
+        const tbody = document.querySelector('#rankings-table tbody');
+        rankings.forEach(row => {
+          const player = row.Player || row.player;
+          const tr = document.createElement('tr');
+          tr.innerHTML = `
+            <td>${row.Ranking || row.Rank}</td>
+            <td>${row.Position}</td>
+            <td>${row.Team}</td>
+            <td>${player}</td>
+            <td>${sentimentMap[player] || ''}</td>
+          `;
+          tbody.appendChild(tr);
+        });
+      } catch (err) {
+        console.error('Error loading data:', err);
+      }
+    }
+
+    loadData();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build `index.html` to fetch ranking and sentiment sheets and display them in a table
- improve documentation about how the page works

## Testing
- `git status --short`