### PR TITLE
Update ADP and Fantasy Points columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ public spreadsheet and populate the table with the following columns:
 - **Team**
 - **Player**
 - **Sentiment** (from column F of the `Sentiment` sheet)
-- **ADP** (column D of the `ADP` sheet)
-- **Fantasy Points** (column W of the `ClayProj` sheet)
+- **ADP** (column J of the `Rankings` sheet)
+- **Fantasy Points** (column I of the `Rankings` sheet)
 
 The spreadsheet ID and sheet names are configured directly in `index.html`.
 

--- a/index.html
+++ b/index.html
@@ -37,8 +37,6 @@
     const sheetId = '1rNouBdE-HbWafu-shO_5JLPSrLhr-xuGpXYfyOI-2oY';
     const rankingsUrl = `https://opensheet.elk.sh/${sheetId}/Rankings`;
     const sentimentUrl = `https://opensheet.elk.sh/${sheetId}/Sentiment`;
-    const adpUrl = `https://opensheet.elk.sh/${sheetId}/ADP`;
-    const clayUrl = `https://opensheet.elk.sh/${sheetId}/ClayProj`;
     // Sentiment scores are stored on the Sentiment tab in column F.
 
     const LEAGUE_ID = 1; // NFL
@@ -78,38 +76,18 @@
 
     async function loadData() {
       try {
-        const [rankingsRes, sentimentRes, adpRes, clayRes] = await Promise.all([
+        const [rankingsRes, sentimentRes] = await Promise.all([
           fetch(rankingsUrl),
           fetch(sentimentUrl),
-          fetch(adpUrl),
-          fetch(clayUrl),
         ]);
         const rankings = await rankingsRes.json();
         const sentimentRows = await sentimentRes.json();
-        const adpRows = await adpRes.json();
-        const clayRows = await clayRes.json();
 
         const sentimentMap = {};
         sentimentRows.forEach(r => {
           const playerName = canonicalName(r.Player || r.player);
           const score = r.Sentiment || r['Sentiment Score'] || r.F || '';
           if (playerName) sentimentMap[playerName] = score;
-        });
-
-        const adpMap = {};
-        adpRows.forEach(r => {
-          const name = canonicalName(r.Player || r.player);
-          const adp = r.D || r.ADP || '';
-          const pct = r.E || r['Percentile Rank'] || r.Percentile || '';
-          if (name) adpMap[name] = { adp, pct };
-        });
-
-        const clayMap = {};
-        clayRows.forEach(r => {
-          const name = canonicalName(r.Player || r.player);
-          const pts = r.W || r['Fantasy Points'] || '';
-          const pct = r.X || r['Percentile Rank'] || r.Percentile || '';
-          if (name) clayMap[name] = { pts, pct };
         });
 
         await fetchPlayers();
@@ -124,24 +102,23 @@
           const sentiment =
             rowSentiment || sentimentMap[canonName] || '';
 
-          const adpInfo = adpMap[canonName] || {};
-          const clayInfo = clayMap[canonName] || {};
+          const adp = row.J || row.ADP || row['ADP'] || '';
+          const fantasyPts =
+            row.I || row['Fantasy Points'] || row['FantasyPts'] || '';
 
           const headshot = headshots[canonName];
           const playerHtml = headshot
             ? `<img src="${headshot}" alt="${player}" style="height:24px;width:24px;vertical-align:middle;margin-right:4px;">${player}`
             : player;
           const tr = document.createElement('tr');
-          tr.dataset.adpPercentile = adpInfo.pct || '';
-          tr.dataset.clayPercentile = clayInfo.pct || '';
           tr.innerHTML = `
             <td>${rank}</td>
             <td>${row.Position}</td>
             <td>${row.Team}</td>
             <td>${playerHtml}</td>
             <td>${sentiment}</td>
-            <td>${adpInfo.adp || ''}</td>
-            <td>${clayInfo.pts || ''}</td>
+            <td>${adp}</td>
+            <td>${fantasyPts}</td>
           `;
           tbody.appendChild(tr);
         });


### PR DESCRIPTION
## Summary
- simplify data fetch logic
- pull ADP and fantasy points directly from Rankings sheet
- document new column locations in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683c8632c6b0832eaad33344d7d3efa6