### PR TITLE
Add percentile values to ADP and fantasy points

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ public spreadsheet and populate the table with the following columns:
 - **Team**
 - **Player**
 - **Sentiment** (from column F of the `Sentiment` sheet)
-- **ADP** (column J of the `Rankings` sheet)
-- **Fantasy Points** (column I of the `Rankings` sheet)
+- **ADP** (column J of the `Rankings` sheet, with percentile from column L of the `ADP` sheet appended in parentheses)
+- **Fantasy Points** (column I of the `Rankings` sheet, with percentile from column W of the `CLayProj` sheet appended in parentheses)
 
 The spreadsheet ID and sheet names are configured directly in `index.html`.
 

--- a/index.html
+++ b/index.html
@@ -85,6 +85,8 @@
     const sheetId = '1rNouBdE-HbWafu-shO_5JLPSrLhr-xuGpXYfyOI-2oY';
     const rankingsUrl = `https://opensheet.elk.sh/${sheetId}/Rankings`;
     const sentimentUrl = `https://opensheet.elk.sh/${sheetId}/Sentiment`;
+    const adpUrl = `https://opensheet.elk.sh/${sheetId}/ADP`;
+    const clayProjUrl = `https://opensheet.elk.sh/${sheetId}/CLayProj`;
     // Sentiment scores are stored on the Sentiment tab in column F.
 
     const LEAGUE_ID = 1; // NFL
@@ -137,20 +139,46 @@
       }
     }
 
+    function getPercentile(row, letter) {
+      if (row[letter]) return row[letter];
+      const key = Object.keys(row).find(k =>
+        canonicalField(k).includes('percentile')
+      );
+      return key ? row[key] : '';
+    }
+
     async function loadData() {
       try {
-        const [rankingsRes, sentimentRes] = await Promise.all([
+        const [rankingsRes, sentimentRes, adpRes, clayRes] = await Promise.all([
           fetch(rankingsUrl),
           fetch(sentimentUrl),
+          fetch(adpUrl),
+          fetch(clayProjUrl),
         ]);
         const rankings = await rankingsRes.json();
         const sentimentRows = await sentimentRes.json();
+        const adpRows = await adpRes.json();
+        const clayRows = await clayRes.json();
 
         const sentimentMap = {};
         sentimentRows.forEach(r => {
           const playerName = canonicalName(r.Player || r.player);
           const score = r.Sentiment || r['Sentiment Score'] || r.F || '';
           if (playerName) sentimentMap[playerName] = score;
+        });
+
+        const adpPctMap = {};
+        adpRows.forEach(r => {
+          const name = canonicalName(r.Player || r.player);
+          const pct = getPercentile(r, 'L');
+          if (name) adpPctMap[name] = pct;
+        });
+
+        const fpPctMap = {};
+        clayRows.forEach(r => {
+          const name = canonicalName(r.Player || r.player);
+          const pct = getPercentile(r, 'W');
+          if (name) fpPctMap[name] = pct;
         });
 
         await fetchPlayers();
@@ -166,7 +194,9 @@
             rowSentiment || sentimentMap[canonName] || '';
 
           const adp = row.J || row.ADP || row['ADP'] || '';
+          const adpPct = adpPctMap[canonName] || '';
           const fantasyPts = getFantasyPoints(row);
+          const fpPct = fpPctMap[canonName] || '';
 
           const headshot = headshots[canonName];
           const playerHtml = headshot
@@ -181,7 +211,9 @@
             sentiment,
             sentimentValue: parseFloat(sentiment),
             adp,
+            adpPct,
             fantasyPts,
+            fpPct,
           };
         });
 
@@ -206,8 +238,8 @@
             <td>${r.team}</td>
             <td>${r.playerHtml}</td>
             <td class="sentiment-cell" style="--width:${percent}%"><span>${r.sentiment}</span></td>
-            <td>${r.adp}</td>
-            <td>${r.fantasyPts}</td>
+            <td>${r.adp}${r.adpPct ? ` (${r.adpPct})` : ''}</td>
+            <td>${r.fantasyPts}${r.fpPct ? ` (${r.fpPct})` : ''}</td>
           `;
           tbody.appendChild(tr);
         });


### PR DESCRIPTION
## Summary
- load percentile data from `ADP` and `CLayProj` sheets
- append the percentile next to ADP and Fantasy Points in the table
- update documentation on new data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683c9b564de8832ea36f21a18a98a55d