### PR TITLE
Improve percentile column detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,12 +126,15 @@
     }
 
     function getFantasyPointsPct(row) {
-      if (row.K || row['Fantasy Points Percentile'] || row['FantasyPts Percentile']) {
-        return row.K || row['Fantasy Points Percentile'] || row['FantasyPts Percentile'];
-      }
+      const direct = getColumn(row, 'K', 'fantasy points percentile');
+      if (direct) return direct;
+
       const key = Object.keys(row).find(k => {
         const ck = canonicalField(k);
-        return ck.includes('fantasypoint') && ck.includes('percent');
+        return (
+          (ck.includes('fantasypoints') || ck.includes('fantasypts') || ck.includes('fp')) &&
+          (ck.includes('percentile') || ck.includes('percent'))
+        );
       });
       return key ? row[key] : '';
     }


### PR DESCRIPTION
## Summary
- broaden detection of fantasy point percentile column in `getFantasyPointsPct`

## Testing
- `node /tmp/test_fp.js`


------
https://chatgpt.com/codex/tasks/task_e_683ca30a505c832eb9fc43e61ef8c860