### PR TITLE
Fix Fantasy Points Sentiment fetch failure

### DIFF
--- a/index.html
+++ b/index.html
@@ -170,13 +170,22 @@
 
     async function loadData() {
       try {
-        const [rankingsRes, sentimentRes, fpSentimentRes] = await Promise.all([
+        const [rankingsRes, sentimentRes] = await Promise.all([
           fetch(rankingsUrl),
           fetch(sentimentUrl),
-          fetch(fpSentimentUrl),
         ]);
         const rankings = await rankingsRes.json();
         const sentimentRows = await sentimentRes.json();
+
+        let fpSentimentRows = [];
+        try {
+          const res = await fetch(fpSentimentUrl);
+          if (res.ok) {
+            fpSentimentRows = await res.json();
+          }
+        } catch (err) {
+          console.warn('Error loading fantasy points sentiment:', err);
+        }
 
         const sentimentMap = {};
         sentimentRows.forEach(r => {
@@ -186,7 +195,6 @@
         });
 
 
-        const fpSentimentRows = await fpSentimentRes.json();
         const fpSentimentMap = {};
         fpSentimentRows.forEach(r => {
           const name = canonicalName(r.Player || r.player);


### PR DESCRIPTION
## Summary
- tolerate failing Fantasy Points Sentiment fetch so rankings table loads

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683cacf07a48832e8b54cf459224f18a