### PR TITLE
Fix FP column mapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@
         const fpPctColMap = {};
         fpPctRows.forEach(r => {
           const name = canonicalName(r.Player || r.player);
-          const fp = getColumn(r, 'K', 'fp pct');
+          const fp = getColumn(r, '', 'fd pct');
           if (name) {
             fpPctColMap[name] = fp;
           }


### PR DESCRIPTION
## Summary
- map Fantasy Points column from `fd pct` instead of `fp pct`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683cb7a93724832e849fb50b08bb6345