### PR TITLE
Format FP percentile as decimal

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ public spreadsheet and populate the table with the following columns:
 - **Team**
 - **Position**
 - **ADP** (column J of the `Rankings` sheet, with percentile from column L of that sheet appended in parentheses)
-- **Fantasy Points** (column I of the `Rankings` sheet, with percentile from column K of that sheet appended in parentheses)
+- **Fantasy Points** (column I of the `Rankings` sheet, with the computed fantasy point percentile appended in parentheses as a decimal between 0 and 1)
 - **Sentiment** (from column F of the `Sentiment` sheet)
 
-- **FP Pct** (percentile rank calculated from each player's fantasy points)
+- **FP Pct** (percentile rank calculated from each player's fantasy points, formatted as a decimal between 0 and 1)
 The spreadsheet ID and sheet names are configured directly in `index.html`.
 
 ### Unabated API

--- a/index.html
+++ b/index.html
@@ -218,7 +218,6 @@
           const adp = row.J || row.ADP || row['ADP'] || '';
           const adpPct = getColumn(row, 'L', 'adp percentile');
           const fantasyPts = getFantasyPoints(row);
-          const fpPct = getFantasyPointsPct(row);
 
           const headshot = headshots[canonName];
           const playerHtml = headshot
@@ -234,7 +233,6 @@
             adp,
             adpPct,
             fantasyPts,
-          fpPct,
           fpPctCol: fpPctColMap[canonName] || "",
         };
       });
@@ -245,11 +243,11 @@
           .sort((a, b) => a - b);
 
         rowsData.forEach(r => {
-          const val = parseFloat(r.fantasyPts);
-          if (!isNaN(val) && numericFps.length) {
-            const rank = numericFps.filter(v => v <= val).length;
-            r.fpPctCol = ((rank / numericFps.length) * 100).toFixed(1);
-          }
+            const val = parseFloat(r.fantasyPts);
+            if (!isNaN(val) && numericFps.length) {
+              const rank = numericFps.filter(v => v <= val).length;
+              r.fpPctCol = (rank / numericFps.length).toFixed(2);
+            }
         });
 
         const numericSentiments = rowsData
@@ -272,7 +270,7 @@
             <td>${r.team}</td>
             <td>${r.position}</td>
             <td>${r.adp}${r.adpPct ? ` (${r.adpPct})` : ''}</td>
-            <td>${r.fantasyPts}${r.fpPct ? ` (${r.fpPct})` : ''}</td>
+            <td>${r.fantasyPts}${r.fpPctCol ? ` (${r.fpPctCol})` : ''}</td>
             <td class="sentiment-cell" style="--width:${percent}%"><span>${r.sentiment}</span></td>
             <td>${r.fpPctCol}</td>
           `;


### PR DESCRIPTION
## Summary
- compute FP percentile on 0–1 scale
- show FP percentile in Fantasy Points column
- document the new format in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683cc25d4a04832ea0627309e2aeb770