### PR TITLE
Revert removal of fpPct percentile logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ public spreadsheet and populate the table with the following columns:
 - **Position**
 - **ADP** (column J of the `Rankings` sheet, with percentile from column L of that sheet appended in parentheses)
 - **wmonighe Rank** (column G of sheet `148406078`)
-- **Fantasy Points** (column I of the `Rankings` sheet)
+- **Fantasy Points** (column I of the `Rankings` sheet, with the computed fantasy point percentile appended in parentheses as a decimal between 0 and 1)
 - **Sentiment** (from column F of the `Sentiment` sheet)
 
 The spreadsheet ID and sheet names are configured directly in `index.html`.

--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
     const sheetId = '1rNouBdE-HbWafu-shO_5JLPSrLhr-xuGpXYfyOI-2oY';
     const rankingsUrl = `https://opensheet.elk.sh/${sheetId}/Rankings`;
     const sentimentUrl = `https://opensheet.elk.sh/${sheetId}/Sentiment`;
-    const wmonigheUrl = `https://opensheet.elk.sh/${sheetId}/148406078`;
+    const fpPctUrl = `https://opensheet.elk.sh/${sheetId}/148406078`;
 
     const LEAGUE_ID = 1;
     const playersUrl =
@@ -161,11 +161,11 @@
         const rankings = await rankingsRes.json();
         const sentimentRows = await sentimentRes.json();
 
-        let wmonigheRows = [];
+        let fpPctRows = [];
         try {
-          const res = await fetch(wmonigheUrl);
+          const res = await fetch(fpPctUrl);
           if (res.ok) {
-            wmonigheRows = await res.json();
+            fpPctRows = await res.json();
           }
         } catch (err) {
           console.warn('Error loading fantasy points sentiment:', err);
@@ -179,7 +179,7 @@
         });
 
         const wmonigheRankMap = {};
-        wmonigheRows.forEach(r => {
+        fpPctRows.forEach(r => {
           const name = canonicalName(r.Player || r.player);
           const wRank = r["wmonighe Rank"] || r["Wmonighe Rank"] || "";
           if (name) {
@@ -219,6 +219,21 @@
           };
         });
 
+        // Add fantasy points percentiles
+        const numericFps = rowsData
+          .map(r => parseFloat(r.fantasyPts))
+          .filter(v => !isNaN(v))
+          .sort((a, b) => a - b);
+
+        rowsData.forEach(r => {
+          const val = parseFloat(r.fantasyPts);
+          if (!isNaN(val) && numericFps.length) {
+            const rank = numericFps.filter(v => v <= val).length;
+            r.fpPct = (rank / numericFps.length).toFixed(2);
+          } else {
+            r.fpPct = '';
+          }
+        });
 
         // Sentiment rendering
         const numericSentiments = rowsData
@@ -242,7 +257,7 @@
             <td>${r.position}</td>
             <td>${r.adp}${r.adpPct ? ` (${r.adpPct})` : ''}</td>
             <td>${r.wmonigheRank}</td>
-            <td>${r.fantasyPts}</td>
+            <td>${r.fantasyPts}${r.fpPct ? ` (${r.fpPct})` : ''}</td>
             <td class="sentiment-cell" style="--width:${percent}%"><span>${r.sentiment}</span></td>
           `;
           tbody.appendChild(tr);


### PR DESCRIPTION
## Summary
- revert PR #53 which removed fantasy point percentile code

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683cdd31f1d0832e911c7a472608bb71