### PR TITLE
Compute wmonighe percentile

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,7 +109,8 @@
       },
       {
         header: '🏅 wmonighe Rank',
-        cell: r => `<td>${r.wmonigheRank}</td>`,
+        cell: r =>
+          `<td>${r.wmonigheRank}${r.wmonighePct ? ' (' + r.wmonighePct + ')' : ''}</td>`,
       },
       {
         header: '📊 ADP',
@@ -243,6 +244,20 @@
             r.fpPct = (rank / numericFps.length).toFixed(2);
           } else {
             r.fpPct = '';
+          }
+        });
+
+        // Add wmonighe rank percentiles (1 -> 1, 300 or below -> 0)
+        rowsData.forEach(r => {
+          const rankVal = parseFloat(r.wmonigheRank);
+          if (!isNaN(rankVal)) {
+            let pct = (300 - rankVal) / 299;
+            if (rankVal >= 300) pct = 0;
+            if (pct > 1) pct = 1;
+            if (pct < 0) pct = 0;
+            r.wmonighePct = pct.toFixed(2);
+          } else {
+            r.wmonighePct = '';
           }
         });
 


### PR DESCRIPTION
## Summary
- add UI support for displaying a percentile next to wmonighe Rank
- compute percentile for wmonighe Rank where 1 -> 1 and 300+ -> 0

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683cee991f28832eb252a1d6ec84f758