### PR TITLE
Add sentiment percentile display

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ public spreadsheet and populate the table with the following columns:
 - **ADP** (column J of the `Rankings` sheet, with percentile from column L of that sheet appended in parentheses)
 - **wmonighe Rank** (column G of the `Rankings` sheet)
 - **Fantasy Points** (column I of the `Rankings` sheet, with the computed fantasy point percentile appended in parentheses as a decimal between 0 and 1)
-- **Sentiment** (from column F of the `Sentiment` sheet)
+- **Sentiment** (from column F of the `Sentiment` sheet, with the computed
+  sentiment percentile appended in parentheses as a decimal between 0 and 1)
 
 The spreadsheet ID and sheet names are configured directly in `index.html`.
 

--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
       {
         header: '😊 Sentiment',
         cell: r =>
-          `<td class="sentiment-cell" style="--width:${r.sentimentPercent}%"><span>${r.sentiment}</span></td>`,
+          `<td class="sentiment-cell" style="--width:${r.sentimentPercent}%"><span>${r.sentiment}${r.sentimentPct ? ' (' + r.sentimentPct + ')' : ''}</span></td>`,
       },
     ];
 
@@ -272,9 +272,14 @@
         const range = maxSentiment - minSentiment || 1;
 
         rowsData.forEach(r => {
-          r.sentimentPercent = !isNaN(r.sentimentValue)
-            ? ((r.sentimentValue - minSentiment) / range) * 100
-            : 0;
+          if (!isNaN(r.sentimentValue)) {
+            const pctRaw = (r.sentimentValue - minSentiment) / range;
+            r.sentimentPercent = pctRaw * 100;
+            r.sentimentPct = pctRaw.toFixed(2);
+          } else {
+            r.sentimentPercent = 0;
+            r.sentimentPct = '';
+          }
         });
 
         const headerRow = document.createElement('tr');


### PR DESCRIPTION
## Summary
- add sentiment percentile display to the Sentiment column
- compute percentile values for sentiment scores
- document the new sentiment percentile column

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683cf055dc98832eacd2fcfb4572f2c2