### PR TITLE
Darken header gradient

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,13 +96,13 @@
       font-size: 3rem;
       font-weight: 700;
       text-align: left;
-      color: #1e90ff; /* Fallback color */
-      background: linear-gradient(90deg, #1e90ff, #00c896);
+      color: #2a3f5c; /* Fallback color */
+      background: linear-gradient(90deg, #2a3f5c, #184040);
       -webkit-background-clip: text;
       -webkit-text-fill-color: transparent;
       background-clip: text;
       text-fill-color: transparent;
-      text-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+      text-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
     }
     .controls {
       display: flex;


### PR DESCRIPTION
## Summary
- tweak styling for page title header so the gradient uses darker colors

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683e44366344832e8d94d6de5e527b47