### PR TITLE
Add Sportradar headshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,22 +26,19 @@ Note: values shown in parentheses represent the percentile rank for that metric.
 
 The spreadsheet ID and sheet names are configured directly in `index.html`.
 
-### Unabated API
+### Player Headshots
 
-Player headshots are loaded from the Unabated API. A `config.js` file is
-included with the repository and already contains the API key needed to connect
-to the service. The page fetches player data for the National Football League
-(league ID `1`) so that headshot URLs can be matched to the rankings:
+Headshots are loaded from Sportradar's Getty Images API. The page downloads the
+player manifest XML once on load and stores a mapping from player name to image
+URL in memory. When building the table, each player's name is preceded by their
+headshot image if available. A small default image is used if the manifest does
+not contain a match.
 
-```javascript
-// config.js
-const UNABATED_API_KEY = 'fwe8yfew80f9wyhb';
+The manifest is fetched from the following endpoint:
+
+```
+https://api.sportradar.us/nfl-images-t3/getty/headshots/players/manifest.xml?api_key=IpzKJTsjR52ZlApIRNRIP7agFKwZRoP214HdrdLu
 ```
 
-No additional setup is required. Simply open the page and it will fetch
-headshots using this key. If you wish to pull a different sport, edit
-`LEAGUE_ID` in `index.html`.
-
-If a headshot is available from Unabated, the Player column will display the
-image directly in front of the player's name.
+No additional setup is required.
 

--- a/index.html
+++ b/index.html
@@ -53,6 +53,14 @@
       position: relative;
       z-index: 1;
     }
+    .headshot {
+      width: 30px;
+      height: 30px;
+      object-fit: cover;
+      border-radius: 50%;
+      margin-right: 8px;
+      vertical-align: middle;
+    }
       .rating-column,
       .rating-cell {
         position: relative;
@@ -359,13 +367,12 @@
     const rankingsUrl = `https://opensheet.elk.sh/${sheetId}/Rankings`;
     const sentimentUrl = `https://opensheet.elk.sh/${sheetId}/Sentiment`;
 
-    const LEAGUE_ID = 1;
-    const playersUrl =
-      typeof UNABATED_API_KEY !== 'undefined'
-        ? `https://partner-api.unabated.com/v2/players?leagues=${LEAGUE_ID}`
-        : null;
+    const HEADSHOTS_MANIFEST_URL =
+      'https://api.sportradar.us/nfl-images-t3/getty/headshots/players/manifest.xml?api_key=IpzKJTsjR52ZlApIRNRIP7agFKwZRoP214HdrdLu';
 
     const headshots = {};
+    const DEFAULT_HEADSHOT =
+      'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==';
 
     const weightInputs = {
       wmonighe: document.getElementById('weight-wmonighe'),
@@ -495,21 +502,25 @@
       return key ? row[key] : '';
     }
 
-    async function fetchPlayers() {
-      if (!playersUrl) return;
+    async function fetchHeadshots() {
       try {
-        const res = await fetch(playersUrl, {
-          headers: { 'x-api-key': UNABATED_API_KEY },
-        });
-        const players = await res.json();
+        const res = await fetch(HEADSHOTS_MANIFEST_URL);
+        const text = await res.text();
+        const xml = new DOMParser().parseFromString(text, 'application/xml');
+        const players = xml.querySelectorAll('player');
         players.forEach(p => {
-          const name = canonicalName(
-            p.preferredName || `${p.firstName} ${p.lastName}` || ''
+          const ref = p.querySelector('ref');
+          if (!ref) return;
+          const name = canonicalName(ref.getAttribute('name') || ref.textContent);
+          const linkNode = Array.from(p.querySelectorAll('links link')).find(l =>
+            l.textContent.includes('h250')
           );
-          if (name) headshots[name] = p.headshotUrl;
+          if (name && linkNode) {
+            headshots[name] = linkNode.textContent;
+          }
         });
       } catch (err) {
-        console.error('Error loading player data:', err);
+        console.error('Error loading headshot data:', err);
       }
     }
 
@@ -693,7 +704,7 @@
           if (playerName) sentimentMap[playerName] = score;
         });
 
-        await fetchPlayers();
+        await fetchHeadshots();
 
         const tbody = document.querySelector('#rankings-table tbody');
         const thead = document.querySelector('#rankings-table thead');
@@ -713,8 +724,9 @@
           const wmonigheRank = getColumn(row, 'G', 'wmonighe rank');
 
           const headshot = headshots[canonName];
-          const playerHtml = headshot
-            ? `<img src="${headshot}" alt="${player}" style="height:24px;width:24px;vertical-align:middle;margin-right:4px;">${player}`
+          const imgSrc = headshot || DEFAULT_HEADSHOT;
+          const playerHtml = imgSrc
+            ? `<img src="${imgSrc}" class="headshot" onerror="this.remove()" /> ${player}`
             : player;
 
           const teamMap = { JAX: 'JAC' };


### PR DESCRIPTION
## Summary
- fetch player headshots from the Sportradar Getty Images manifest
- display the images in the Player column using new `.headshot` CSS
- document new headshot source in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f8cf62ef8832ea8d5f4cfcbdc91bb