### PR TITLE
Replace invalid ADP with Undrafted

### DIFF
--- a/index.html
+++ b/index.html
@@ -519,7 +519,13 @@
       },
       {
         header: '📊 ADP',
-        cell: r => `<td>${r.adp}${r.adpPct ? ' (' + r.adpPct + ')' : ''}</td>`,
+        cell: r => {
+          let text = `${r.adp}${r.adpPct ? ' (' + r.adpPct + ')' : ''}`;
+          if (text === '#N/A (#N/A)' || text === '- (#VALUE!)') {
+            text = 'Undrafted';
+          }
+          return `<td>${text}</td>`;
+        },
         sortKey: 'adp',
       },
       {


### PR DESCRIPTION
## Summary
- show **Undrafted** when ADP data contains `#N/A (#N/A)` or `- (#VALUE!)`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840de124f84832e8455506e5f7314ad