### PR TITLE
Assign 0 ADP percentile for undrafted players

### DIFF
--- a/index.html
+++ b/index.html
@@ -521,7 +521,11 @@
         header: '📊 ADP',
         cell: r => {
           let text = `${r.adp}${r.adpPct ? ' (' + r.adpPct + ')' : ''}`;
-          if (text === '#N/A (#N/A)' || text === '- (#VALUE!)') {
+          if (
+            r.adp === 'Undrafted' ||
+            text === '#N/A (#N/A)' ||
+            text === '- (#VALUE!)'
+          ) {
             text = 'Undrafted';
           }
           return `<td>${text}</td>`;
@@ -800,8 +804,19 @@
             row.Sentiment || row['Sentiment Score'] || row.H || '';
           const sentiment =
             rowSentiment || sentimentMap[canonName] || '';
-          const adp = row.J || row.ADP || row['ADP'] || '';
-          const adpPct = getColumn(row, 'L', 'adp percentile');
+          let adp = row.J || row.ADP || row['ADP'] || '';
+          let adpPct = getColumn(row, 'L', 'adp percentile');
+          const isUndrafted =
+            adp.toString().toLowerCase() === 'undrafted' ||
+            adp === '#N/A' ||
+            adp === '-' ||
+            adpPct === '#N/A' ||
+            adpPct === '#VALUE!' ||
+            adpPct === '';
+          if (isUndrafted) {
+            adp = 'Undrafted';
+            adpPct = '0.00';
+          }
           const fantasyPts = getFantasyPoints(row);
           const wmonigheRank = getColumn(row, 'G', 'wmonighe rank');
 


### PR DESCRIPTION
## Summary
- show ADP as Undrafted when missing and include its percentile in rating
- treat undrafted ADP values as 0.00 percentile during data load

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840ecc4c670832e80647ee16a3614c5