### PR TITLE
Add VORP column

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ recompute ratings.
 - **Fantasy Points** (column I of the `Rankings` sheet, with the computed fantasy point percentile appended in parentheses as a decimal between 0 and 1)
 - **Sentiment** (from column F of the `Sentiment` sheet, with the computed
   sentiment percentile appended in parentheses as a decimal between 0 and 1)
+- **VORP Score** (column Q of the `Rankings` sheet)
 
 Note: values shown in parentheses represent the percentile rank for that metric.
 

--- a/index.html
+++ b/index.html
@@ -548,6 +548,11 @@
           `<td class="sentiment-cell" style="--width:${r.sentimentPercent}%"><span>${r.sentiment}${r.sentimentPct ? ' (' + r.sentimentPct + ')' : ''}</span></td>`,
         sortKey: 'sentimentValue',
       },
+      {
+        header: '📈 VORP Score',
+        cell: r => `<td>${r.vorp}</td>`,
+        sortKey: 'vorp',
+      },
     ];
 
     function canonicalName(name) {
@@ -845,6 +850,7 @@
             adpPct,
             postDraftId: getColumn(row, 'P', 'post draft id'),
             wmonigheRank,
+            vorp: getColumn(row, 'Q', 'vorp score'),
             fantasyPts,
           };
         });


### PR DESCRIPTION
## Summary
- display VORP Score from column Q of the Google Sheet
- document the VORP Score column in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843798f6b7c832e87a42d740875c5c6