### PR TITLE
Show VORP percentile in table

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ recompute ratings.
 - **Fantasy Points** (column I of the `Rankings` sheet, with the computed fantasy point percentile appended in parentheses as a decimal between 0 and 1)
 - **Sentiment** (from column F of the `Sentiment` sheet, with the computed
   sentiment percentile appended in parentheses as a decimal between 0 and 1)
-- **VORP Score** (column Q of the `Rankings` sheet)
+ - **VORP Score** (column Q of the `Rankings` sheet, with percentile from column R appended in parentheses)
 
 Note: values shown in parentheses represent the percentile rank for that metric.
 

--- a/index.html
+++ b/index.html
@@ -546,7 +546,8 @@
       },
       {
         header: '📈 VORP Score',
-        cell: r => `<td>${r.vorp}</td>`,
+        cell: r =>
+          `<td>${r.vorp}${r.vorpPct ? ' (' + r.vorpPct + ')' : ''}</td>`,
         sortKey: 'vorp',
       },
     ];
@@ -847,6 +848,7 @@
             postDraftId: getColumn(row, 'P', 'post draft id'),
             wmonigheRank,
             vorp: getColumn(row, 'Q', 'vorp score'),
+            vorpPct: getColumn(row, 'R', 'vorp percentile'),
             fantasyPts,
           };
         });


### PR DESCRIPTION
## Summary
- display VORP percentile next to the VORP score
- document the new VORP percentile field in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68437c382b8c832ebd11c2030f3fbbaa