### PR TITLE
Round VORP percentile

### DIFF
--- a/index.html
+++ b/index.html
@@ -891,6 +891,16 @@
           }
         });
 
+        // Round VORP score percentile
+        rowsData.forEach(r => {
+          const val = parseFloat(r.vorpPct);
+          if (!isNaN(val)) {
+            r.vorpPct = val.toFixed(2);
+          } else {
+            r.vorpPct = '';
+          }
+        });
+
         // Sentiment rendering
         const numericSentiments = rowsData
           .map(r => r.sentimentValue)


### PR DESCRIPTION
## Summary
- round VORP score percentile to two decimal places when loading data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684380433e1c832e8edf3c9ff12e2169