### PR TITLE
Add rating column in portfolio

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -58,9 +58,172 @@
       "Weekly Winner Size"
     ];
 
-    document.getElementById("file-input").addEventListener("change", function(e) {
+    const sheetId = '1rNouBdE-HbWafu-shO_5JLPSrLhr-xuGpXYfyOI-2oY';
+    const rankingsUrl = `https://opensheet.elk.sh/${sheetId}/Rankings`;
+    const sentimentUrl = `https://opensheet.elk.sh/${sheetId}/Sentiment`;
+
+    function canonicalName(name) {
+      return (name || '')
+        .toString()
+        .toLowerCase()
+        .replace(/[.'’]/g, '')
+        .replace(/[^a-z0-9]+/g, ' ')
+        .trim();
+    }
+
+    function canonicalField(name) {
+      return (name || '').toString().toLowerCase().replace(/[^a-z0-9]/g, '');
+    }
+
+    function getFantasyPoints(row) {
+      if (row.I || row['Fantasy Points'] || row['FantasyPts']) {
+        return row.I || row['Fantasy Points'] || row['FantasyPts'];
+      }
+      const key = Object.keys(row).find(k => {
+        const ck = canonicalField(k);
+        return ck.includes('fantasypoints') || ck.includes('fantasypts');
+      });
+      return key ? row[key] : '';
+    }
+
+    function getColumn(row, letter, labelPart) {
+      if (row[letter]) return row[letter];
+      const target = canonicalField(labelPart);
+      const key = Object.keys(row).find(k =>
+        canonicalField(k).includes(target)
+      );
+      return key ? row[key] : '';
+    }
+
+    const ratingMap = {};
+    const ratingsPromise = loadRatings();
+
+    async function loadRatings() {
+      try {
+        const [rankRes, sentRes] = await Promise.all([
+          fetch(rankingsUrl),
+          fetch(sentimentUrl)
+        ]);
+        const rankings = await rankRes.json();
+        const sentimentRows = await sentRes.json();
+
+        const sentimentMap = {};
+        sentimentRows.forEach(r => {
+          const playerName = canonicalName(r.Player || r.player);
+          const score = r.Sentiment || r['Sentiment Score'] || r.F || '';
+          if (playerName) sentimentMap[playerName] = score;
+        });
+
+        const rowsData = rankings.map(row => {
+          const player = row.Player || row.player;
+          const canon = canonicalName(player);
+          const rowSentiment = row.Sentiment || row['Sentiment Score'] || row.H || '';
+          const sentiment = rowSentiment || sentimentMap[canon] || '';
+          let adp = row.J || row.ADP || row['ADP'] || '';
+          let adpPct = getColumn(row, 'L', 'adp percentile');
+          const isUndrafted =
+            adp.toString().toLowerCase() === 'undrafted' ||
+            adp === '#N/A' ||
+            adp === '-' ||
+            adpPct === '#N/A' ||
+            adpPct === '#VALUE!' ||
+            adpPct === '';
+          if (isUndrafted) {
+            adp = 'Undrafted';
+            adpPct = '0.00';
+          }
+          const fantasyPts = getFantasyPoints(row);
+          const wmonigheRank = getColumn(row, 'G', 'wmonighe rank');
+          return {
+            player,
+            sentimentValue: parseFloat(sentiment),
+            adpPct,
+            wmonigheRank,
+            vorpPct: getColumn(row, 'R', 'vorp percentile'),
+            fantasyPts
+          };
+        });
+
+        const numericFps = rowsData
+          .map(r => parseFloat(r.fantasyPts))
+          .filter(v => !isNaN(v))
+          .sort((a, b) => a - b);
+
+        rowsData.forEach(r => {
+          const val = parseFloat(r.fantasyPts);
+          if (!isNaN(val) && numericFps.length) {
+            const rank = numericFps.filter(v => v <= val).length;
+            r.fpPct = (rank / numericFps.length).toFixed(2);
+          } else {
+            r.fpPct = '';
+          }
+        });
+
+        rowsData.forEach(r => {
+          const rankVal = parseFloat(r.wmonigheRank);
+          if (!isNaN(rankVal)) {
+            let pct = (300 - rankVal) / 299;
+            if (rankVal >= 300) pct = 0;
+            if (pct > 1) pct = 1;
+            if (pct < 0) pct = 0;
+            r.wmonighePct = pct.toFixed(2);
+          } else {
+            r.wmonighePct = '';
+          }
+        });
+
+        rowsData.forEach(r => {
+          const val = parseFloat(r.vorpPct);
+          if (!isNaN(val)) {
+            r.vorpPct = parseFloat(val).toFixed(2);
+          } else {
+            r.vorpPct = '';
+          }
+        });
+
+        const numericSentiments = rowsData
+          .map(r => r.sentimentValue)
+          .filter(v => !isNaN(v));
+        const minSentiment = numericSentiments.length ? Math.min(...numericSentiments) : 0;
+        const maxSentiment = numericSentiments.length ? Math.max(...numericSentiments) : 0;
+        const range = maxSentiment - minSentiment || 1;
+
+        rowsData.forEach(r => {
+          if (!isNaN(r.sentimentValue)) {
+            const pctRaw = (r.sentimentValue - minSentiment) / range;
+            r.sentimentPct = pctRaw.toFixed(2);
+          } else {
+            r.sentimentPct = '';
+          }
+        });
+
+        const weights = { wmonighe: 0.35, adp: 0.35, fp: 0.1, sentiment: 0.05, vorp: 0.15 };
+
+        rowsData.forEach(r => {
+          const items = [
+            { v: parseFloat(r.wmonighePct), w: weights.wmonighe },
+            { v: parseFloat(r.adpPct), w: weights.adp },
+            { v: parseFloat(r.fpPct), w: weights.fp },
+            { v: parseFloat(r.sentimentPct), w: weights.sentiment },
+            { v: parseFloat(r.vorpPct), w: weights.vorp }
+          ].filter(i => !isNaN(i.v) && i.w > 0);
+          const totalWeight = items.reduce((a, b) => a + b.w, 0);
+          let rating = '';
+          if (items.length && totalWeight > 0) {
+            const sum = items.reduce((s, i) => s + i.v * i.w, 0);
+            rating = (sum / totalWeight).toFixed(2);
+          }
+          ratingMap[canonicalName(r.player)] = rating;
+        });
+      } catch (err) {
+        console.error('Error loading ratings', err);
+      }
+    }
+
+    document.getElementById("file-input").addEventListener("change", async function(e) {
       const file = e.target.files[0];
       if (!file) return;
+      await ratingsPromise;
       const reader = new FileReader();
       reader.onload = function(event) {
         try {
@@ -99,14 +262,16 @@
             card.appendChild(header);
             const table = document.createElement("table");
             const thead = document.createElement("thead");
-            thead.innerHTML = "<tr><th>Pick Number</th><th>First Name</th><th>Last Name</th><th>Team</th><th>Position</th></tr>";
+            thead.innerHTML = "<tr><th>Pick Number</th><th>First Name</th><th>Last Name</th><th>Team</th><th>Position</th><th>Rating</th></tr>";
             table.appendChild(thead);
             const tbody = document.createElement("tbody");
-            team.picks.forEach(p => {
-              const tr = document.createElement("tr");
-              tr.innerHTML = `<td>${p["Pick Number"]}</td><td>${p["First Name"]}</td><td>${p["Last Name"]}</td><td>${p["Team"]}</td><td>${p["Position"]}</td>`;
-              tbody.appendChild(tr);
-            });
+              team.picks.forEach(p => {
+                const tr = document.createElement("tr");
+                const canon = canonicalName(`${p["First Name"]} ${p["Last Name"]}`);
+                const rating = ratingMap[canon] || '';
+                tr.innerHTML = `<td>${p["Pick Number"]}</td><td>${p["First Name"]}</td><td>${p["Last Name"]}</td><td>${p["Team"]}</td><td>${p["Position"]}</td><td>${rating}</td>`;
+                tbody.appendChild(tr);
+              });
             table.appendChild(tbody);
             card.appendChild(table);
             teamsEl.appendChild(card);


### PR DESCRIPTION
## Summary
- compute player ratings from the Rankings/ Sentiment sheets using default weights
- add a `Rating` column on portfolio tables and fill values for each pick

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844c625f42c832e94b7e17d175fd572