### PR TITLE
Implement portfolio page styling

### DIFF
--- a/exposureRater.js
+++ b/exposureRater.js
@@ -1,0 +1,50 @@
+const uploader   = document.querySelector('.uploader');
+const csvInput   = document.getElementById('csvInput');
+const browseBtn  = document.getElementById('browseBtn');
+const grid       = document.querySelector('.teams-grid');
+
+browseBtn.onclick = () => csvInput.click();
+uploader.ondragover = e => { e.preventDefault(); uploader.classList.add('drag'); };
+uploader.ondragleave = () => uploader.classList.remove('drag');
+uploader.ondrop = e => {
+  e.preventDefault(); uploader.classList.remove('drag');
+  handleFiles(e.dataTransfer.files);
+};
+csvInput.onchange  = () => handleFiles(csvInput.files);
+
+async function handleFiles(fileList){
+  const file = fileList[0];
+  if(!file) return;
+  const formData = new FormData(); formData.append('file', file);
+  const res = await fetch('/api/exposure-rate',{ method:'POST', body:formData });
+  if(!res.ok){ return showError('Upload failed'); }
+  const teams = await res.json();
+  renderTeams(teams);
+}
+
+function renderTeams(teams){
+  grid.innerHTML = '';
+  teams.forEach(team=>{
+    const card = document.createElement('article');
+    card.className = 'team-card';
+    card.innerHTML = `
+      <h2>${team.name} – <span class="badge-rating r${Math.floor(team.rating)}">${team.rating.toFixed(2)}</span></h2>
+      ${buildTable(team.roster)}
+    `;
+    grid.appendChild(card);
+  });
+  document.querySelector('[data-state="empty"]').hidden = true;
+  grid.hidden = false;
+}
+
+function buildTable(rows){
+  const head = `<thead><tr>${Object.keys(rows[0]).map(k=>`<th>${k}</th>`).join('')}</tr></thead>`;
+  const body = `<tbody>${rows.map(r=>`<tr>${Object.values(r).map(v=>`<td>${v}</td>`).join('')}</tr>`).join('')}</tbody>`;
+  return `<table>${head}${body}</table>`;
+}
+
+function showError(msg){
+  // TODO insert alert component
+}
+
+export { renderTeams };

--- a/exposureRater.module.css
+++ b/exposureRater.module.css
@@ -1,0 +1,133 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@500;600;700&display=swap');
+
+:root {
+  --brand-primary: #0060ff;
+  --brand-primary-dk:#004bd1;
+  --neutral-900: #0c1e25;
+  --neutral-700: #34454d;
+  --neutral-200: #e5e8ec;
+  --neutral-050: #f9fafb;
+  --success-600: #2e974b;
+  --danger-600: #c0303b;
+
+  --space-1: 0.25rem;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1.25rem;
+  --space-5: 2rem;
+}
+
+.page {
+  padding-inline: var(--space-5);
+}
+.page-title {
+  margin-block: var(--space-5) var(--space-4);
+  color: var(--neutral-900);
+}
+
+.uploader {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-3);
+  border: 2px dashed var(--neutral-200);
+  padding: var(--space-5);
+  border-radius: 8px;
+  background: var(--neutral-050);
+  transition: border .2s;
+}
+.uploader.drag {
+  border-color: var(--brand-primary);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: .55rem 1.1rem;
+  border-radius: 8px;
+  font-weight: 600;
+  font-size: .95rem;
+  cursor: pointer;
+  transition: all .15s ease;
+}
+.btn svg {
+  width: 1em;
+  height: 1em;
+  margin-right: .4em;
+}
+
+.btn-primary {
+  background: var(--brand-primary);
+  color: #fff;
+  border: 1px solid transparent;
+}
+.btn-primary:hover {
+  background: var(--brand-primary-dk);
+}
+
+.btn-secondary {
+  background: #fff;
+  color: var(--brand-primary);
+  border: 1px solid var(--brand-primary);
+}
+.btn-secondary:hover {
+  background: rgba(0, 96, 255, .08);
+}
+
+.teams-grid {
+  margin-top: var(--space-5);
+  display: grid;
+  gap: var(--space-5);
+  grid-template-columns: repeat(auto-fit, minmax(24rem, 1fr));
+}
+
+.team-card {
+  background: #fff;
+  border: 1px solid var(--neutral-200);
+  border-radius: 8px;
+  box-shadow: 0 2px 6px rgba(0,0,0,.05);
+  display: flex;
+  flex-direction: column;
+}
+.team-card h2 {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin: var(--space-3);
+}
+.team-card table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: .85rem;
+}
+.team-card th,
+.team-card td {
+  padding: .35rem .5rem;
+  text-align: left;
+  border: 1px solid var(--neutral-200);
+}
+.team-card tbody tr:nth-child(odd) {
+  background: var(--neutral-050);
+}
+
+.badge-rating {
+  display: inline-block;
+  min-width: 2rem;
+  text-align: center;
+  border-radius: 999px;
+  padding: .15rem .5rem;
+  color: #fff;
+  font-weight: 600;
+}
+
+.r10,
+.r9 { background: #2e974b; }
+.r8,
+.r7 { background: #55b04f; }
+.r6,
+.r5 { background: #ffd54f; color: #000; }
+.r4,
+.r3 { background: #f29339; }
+.r2,
+.r1,
+.r0 { background: #c0303b; }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "type": "module",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.6.1",
+    "jsdom": "^22.1.0"
+  }
+}

--- a/portfolio.html
+++ b/portfolio.html
@@ -5,202 +5,30 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Upload Exposure CSV</title>
   <link rel="icon" type="image/svg+xml" href="favicon.svg" />
-  <style>
-    body {
-      font-family: Arial, sans-serif;
-      padding: 2rem;
-    }
-    #teams{display:flex;flex-wrap:wrap;gap:1rem;}
-    .team-card{border:1px solid #ddd;padding:1rem;margin-top:1rem;border-radius:4px;flex:1 0 calc(33.333% - 1rem);box-sizing:border-box;}
-    .team-card h2{margin-top:0;}
-    .team-card table{width:100%;border-collapse:collapse;margin-top:0.5rem;}
-    .team-card.roster-18 table,.team-card.roster-20 table{overflow:hidden;}
-    .team-card th,.team-card td{border:1px solid #ccc;padding:4px;text-align:left;font-size:0.9rem;}
-    .modal{display:none;position:fixed;top:0;left:0;right:0;bottom:0;background:rgba(0,0,0,0.5);align-items:center;justify-content:center;}
-    .modal.show{display:flex;}
-    .modal-content{background:#fff;padding:1rem;border-radius:4px;width:90%;max-width:500px;}
-    .upload-row{display:flex;align-items:center;margin-bottom:1rem;gap:0.5rem;}
-    .status{font-weight:bold;}
-    .success{color:green;}
-    .error{color:red;}
-  </style>
+  <link rel="stylesheet" href="exposureRater.module.css" />
 </head>
 <body>
-  <h1>Upload Exposure CSV</h1>
-  <button id="open-modal">Upload Exposure CSV</button>
-  <div id="message"></div>
-  <div id="teams"></div>
+  <svg style="display:none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <symbol id="arrow-up-tray" viewBox="0 0 24 24">
+      <path d="M3 16.5V21h18v-4.5" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+      <path d="M12 3v12m0 0l-3.75-3.75M12 15l3.75-3.75" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    </symbol>
+  </svg>
 
-  <div id="upload-modal" class="modal">
-    <div class="modal-content">
-      <h2>Select CSVs to Upload</h2>
-      <div class="upload-row">
-        <span>Pre-Draft (Underdog)</span>
-        <input type="file" id="pre-file" accept=".csv">
-        <span id="pre-status" class="status"></span>
-      </div>
-      <div class="upload-row">
-        <span>Post-Draft (Underdog)</span>
-        <input type="file" id="post-file" accept=".csv">
-        <span id="post-status" class="status"></span>
-      </div>
-      <div class="upload-row">
-        <span>Eliminator</span>
-        <input type="file" id="elim-file" accept=".csv">
-        <span id="elim-status" class="status"></span>
-      </div>
-      <button id="upload-done">Done</button>
-    </div>
-  </div>
+  <main class="page portfolio">
+    <h1 class="page-title">Upload Exposure CSV</h1>
+    <section class="uploader" aria-labelledby="csvLabel" data-state="empty">
+      <label id="csvLabel" class="visually-hidden">Upload exposure CSV</label>
+      <input id="csvInput" type="file" accept=".csv" hidden />
+      <button type="button" class="btn btn-primary" id="browseBtn">
+        <svg class="icon"><use href="#arrow-up-tray"/></svg>
+        Upload CSV
+      </button>
+      <p class="hint">Drag & drop or click to browse</p>
+    </section>
+    <section class="teams-grid" hidden></section>
+  </main>
 
-  <script>
-    const requiredHeaders = [
-      "Picked At","Pick Number","Appearance","First Name","Last Name","Team","Position","Draft","Draft Entry","Draft Entry Fee","Draft Size","Draft Total Prizes","Tournament Title","Tournament","Tournament Entry Fee","Tournament Total Prizes","Tournament Size","Draft Pool Title","Draft Pool","Draft Pool Entry Fee","Draft Pool Total Prizes","Draft Pool Size","Weekly Winner Title","Weekly Winner","Weekly Winner Entry Fee","Weekly Winner Total Prizes","Weekly Winner Size"
-    ];
-
-    const sheetId = '1rNouBdE-HbWafu-shO_5JLPSrLhr-xuGpXYfyOI-2oY';
-    const rankingsUrl = `https://opensheet.elk.sh/${sheetId}/Rankings`;
-    const sentimentUrl = `https://opensheet.elk.sh/${sheetId}/Sentiment`;
-
-    function canonicalName(name){return (name||'').toString().toLowerCase().replace(/[.'’]/g,'').replace(/[^a-z0-9]+/g,' ').trim();}
-    function canonicalField(name){return (name||'').toString().toLowerCase().replace(/[^a-z0-9]/g,'');}
-
-    function getFantasyPoints(row){
-      if(row.I||row['Fantasy Points']||row['FantasyPts']) return row.I||row['Fantasy Points']||row['FantasyPts'];
-      const key=Object.keys(row).find(k=>{const ck=canonicalField(k);return ck.includes('fantasypoints')||ck.includes('fantasypts');});
-      return key?row[key]:'';
-    }
-
-    function getColumn(row,letter,labelPart){
-      if(row[letter]) return row[letter];
-      const target=canonicalField(labelPart);
-      const key=Object.keys(row).find(k=>canonicalField(k).includes(target));
-      return key?row[key]:'';
-    }
-
-    const ratingMap={};
-    const ratingsPromise=loadRatings();
-
-    async function loadRatings(){
-      try{
-        const[rankRes,sentRes]=await Promise.all([fetch(rankingsUrl),fetch(sentimentUrl)]);
-        const rankings=await rankRes.json();
-        const sentimentRows=await sentRes.json();
-        const sentimentMap={};
-        sentimentRows.forEach(r=>{const playerName=canonicalName(r.Player||r.player);const score=r.Sentiment||r['Sentiment Score']||r.F||'';if(playerName)sentimentMap[playerName]=score;});
-        const rowsData=rankings.map(row=>{const player=row.Player||row.player;const canon=canonicalName(player);const rowSentiment=row.Sentiment||row['Sentiment Score']||row.H||'';const sentiment=rowSentiment||sentimentMap[canon]||'';let adp=row.J||row.ADP||row['ADP']||'';let adpPct=getColumn(row,'L','adp percentile');const isUndrafted=adp.toString().toLowerCase()==='undrafted'||adp==='#N/A'||adp==='-'||adpPct==='#N/A'||adpPct==='#VALUE!'||adpPct==='';if(isUndrafted){adp='Undrafted';adpPct='0.00';}const fantasyPts=getFantasyPoints(row);const wmonigheRank=getColumn(row,'G','wmonighe rank');return{player,sentimentValue:parseFloat(sentiment),adpPct,wmonigheRank,vorpPct:getColumn(row,'R','vorp percentile'),fantasyPts};});
-        const numericFps=rowsData.map(r=>parseFloat(r.fantasyPts)).filter(v=>!isNaN(v)).sort((a,b)=>a-b);
-        rowsData.forEach(r=>{const val=parseFloat(r.fantasyPts);if(!isNaN(val)&&numericFps.length){const rank=numericFps.filter(v=>v<=val).length;r.fpPct=(rank/numericFps.length).toFixed(2);}else{r.fpPct='';}});
-        rowsData.forEach(r=>{const rankVal=parseFloat(r.wmonigheRank);if(!isNaN(rankVal)){let pct=(300-rankVal)/299;if(rankVal>=300)pct=0;if(pct>1)pct=1;if(pct<0)pct=0;r.wmonighePct=pct.toFixed(2);}else{r.wmonighePct='';}});
-        rowsData.forEach(r=>{const val=parseFloat(r.vorpPct);r.vorpPct=!isNaN(val)?parseFloat(val).toFixed(2):'';});
-        const numericSentiments=rowsData.map(r=>r.sentimentValue).filter(v=>!isNaN(v));
-        const minSentiment=numericSentiments.length?Math.min(...numericSentiments):0;
-        const maxSentiment=numericSentiments.length?Math.max(...numericSentiments):0;
-        const range=maxSentiment-minSentiment||1;
-        rowsData.forEach(r=>{if(!isNaN(r.sentimentValue)){const pctRaw=(r.sentimentValue-minSentiment)/range;r.sentimentPct=pctRaw.toFixed(2);}else{r.sentimentPct='';}});
-        const weights={wmonighe:0.35,adp:0.35,fp:0.1,sentiment:0.05,vorp:0.15};
-        rowsData.forEach(r=>{const items=[{v:parseFloat(r.wmonighePct),w:weights.wmonighe},{v:parseFloat(r.adpPct),w:weights.adp},{v:parseFloat(r.fpPct),w:weights.fp},{v:parseFloat(r.sentimentPct),w:weights.sentiment},{v:parseFloat(r.vorpPct),w:weights.vorp}].filter(i=>!isNaN(i.v)&&i.w>0);const totalWeight=items.reduce((a,b)=>a+b.w,0);let rating='';if(items.length&&totalWeight>0){const sum=items.reduce((s,i)=>s+i.v*i.w,0);rating=(sum/totalWeight).toFixed(2);}ratingMap[canonicalName(r.player)]=rating;});
-      }catch(err){console.error('Error loading ratings',err);}
-    }
-
-    const allTeams=[];
-
-    async function handleFile(file,statusEl){
-      if(!file)return;
-      await ratingsPromise;
-      try{
-        const text=await file.text();
-        const lines=text.trim().split(/\r?\n/).filter(l=>l.trim()!=='');
-        const headers=lines[0].split(',').map(h=>h.trim());
-        const allPresent=requiredHeaders.every(h=>headers.includes(h));
-        if(!allPresent){statusEl.textContent='\u2717 Upload Failure';statusEl.className='status error';return;}
-        const rows=lines.slice(1).map(line=>{const values=line.split(',').map(v=>v.trim());const obj={};headers.forEach((h,i)=>obj[h]=values[i]);return obj;});
-        const teams={};
-        rows.forEach(r=>{const key=r['Draft Entry'];if(!teams[key]){teams[key]={tournamentTitle:r['Tournament Title'],entryFee:r['Tournament Entry Fee'],picks:[]};}teams[key].picks.push(r);});
-        const teamArr=Object.values(teams);
-        teamArr.forEach(team=>{
-          team.picks.sort((a,b)=>parseInt(a['Pick Number'],10)-parseInt(b['Pick Number'],10));
-          const firstPick=team.picks[0];
-          let dateEntered='';
-          if(firstPick&&firstPick['Picked At']){const d=new Date(firstPick['Picked At']);if(!isNaN(d)){const mm=String(d.getMonth()+1).padStart(2,'0');const dd=String(d.getDate()).padStart(2,'0');dateEntered=`${mm}/${dd}`;}}
-          team.dateEntered=dateEntered;
-          const rosterSize=team.picks.length;
-          team.rosterSize=rosterSize;
-          team.totalRating=team.picks.reduce((sum,p)=>{const canon=canonicalName(`${p['First Name']} ${p['Last Name']}`);const rating=parseFloat(ratingMap[canon]);return sum+(isNaN(rating)?0:rating);},0);
-          if(rosterSize===20){
-            team.totalRating=team.totalRating*(18/20);
-          }
-        });
-        allTeams.push(...teamArr);
-        statusEl.textContent='\u2713 Upload Successful';
-        statusEl.className='status success';
-      }catch(err){
-        statusEl.textContent='\u2717 Upload Failure';
-        statusEl.className='status error';
-      }
-    }
-
-    function renderTeams(teams){
-      const teamsEl=document.getElementById('teams');
-      teamsEl.innerHTML='';
-      teams.sort((a,b)=>b.totalRating-a.totalRating);
-      teams.forEach(team=>{
-        const card=document.createElement('div');
-        card.className=`team-card roster-${team.rosterSize}`;
-        const header=document.createElement('h2');
-        const feeDisp=parseFloat(team.entryFee).toString();
-        const datePart=team.dateEntered?` - Date Entered: ${team.dateEntered}`:'';
-        header.textContent=`${team.tournamentTitle} - $${feeDisp}${datePart} - Total Rating: ${team.totalRating.toFixed(2)}`;
-        card.appendChild(header);
-        const table=document.createElement('table');
-        const thead=document.createElement('thead');
-        thead.innerHTML='<tr><th>Pick Number</th><th>First Name</th><th>Last Name</th><th>Team</th><th>Position</th><th>Rating</th></tr>';
-        table.appendChild(thead);
-        const tbody=document.createElement('tbody');
-        team.picks.forEach(p=>{
-          const tr=document.createElement('tr');
-          const canon=canonicalName(`${p['First Name']} ${p['Last Name']}`);
-          const rating=ratingMap[canon]||'';
-          tr.innerHTML=`<td>${p['Pick Number']}</td><td>${p['First Name']}</td><td>${p['Last Name']}</td><td>${p['Team']}</td><td>${p['Position']}</td><td>${rating}</td>`;
-          tbody.appendChild(tr);
-        });
-        table.appendChild(tbody);
-        card.appendChild(table);
-        teamsEl.appendChild(card);
-      });
-      requestAnimationFrame(standardizeTableHeights);
-    }
-
-    function standardizeTableHeights(){
-      ['18','20'].forEach(size=>{
-        const tables=document.querySelectorAll(`.team-card.roster-${size} table`);
-        let max=0;
-        tables.forEach(t=>{if(t.offsetHeight>max)max=t.offsetHeight;});
-        tables.forEach(t=>{if(max)t.style.height=max+'px';});
-      });
-    }
-
-    document.getElementById('open-modal').addEventListener('click',()=>{
-      document.getElementById('upload-modal').classList.add('show');
-    });
-
-    document.getElementById('upload-done').addEventListener('click',()=>{
-      document.getElementById('upload-modal').classList.remove('show');
-      renderTeams(allTeams);
-    });
-
-    document.getElementById('pre-file').addEventListener('change',e=>{
-      handleFile(e.target.files[0],document.getElementById('pre-status'));
-      e.target.value='';
-    });
-    document.getElementById('post-file').addEventListener('change',e=>{
-      handleFile(e.target.files[0],document.getElementById('post-status'));
-      e.target.value='';
-    });
-    document.getElementById('elim-file').addEventListener('change',e=>{
-      handleFile(e.target.files[0],document.getElementById('elim-status'));
-      e.target.value='';
-    });
-  </script>
+  <script type="module" src="exposureRater.js"></script>
 </body>
 </html>

--- a/renderTeams.test.js
+++ b/renderTeams.test.js
@@ -1,0 +1,11 @@
+import { JSDOM } from 'jsdom';
+import { renderTeams } from './exposureRater.js';
+
+test('renderTeams adds cards to the grid', () => {
+  const dom = new JSDOM('<main><section class="teams-grid"></section><div data-state="empty"></div></main>', { runScripts: 'outside-only' });
+  global.document = dom.window.document;
+  const teams = [{ name: 'Test', rating: 9.2, roster: [{ a:1 }] }];
+  renderTeams(teams);
+  const cards = dom.window.document.querySelectorAll('.team-card');
+  expect(cards.length).toBe(1);
+});


### PR DESCRIPTION
## Summary
- redesign `portfolio.html` with uploader hero layout
- add stylesheet `exposureRater.module.css`
- add JS logic from spec in `exposureRater.js`
- include minimal Jest test skeleton for `renderTeams`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68495e9370ec832ea136370517596465