### PR TITLE
Add server for CSV uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,16 @@ The spreadsheet ID and sheet names are configured directly in `index.html`.
 Each player's row displays the logo of their NFL team to the left of their name.
 Logos are loaded directly from FantasyNerds and no additional setup is required.
 
+## Running the Server
+
+A small Express server is included to parse uploaded CSV files for the
+exposure rater tool. Install dependencies with `npm install` and start
+the server:
+
+```bash
+npm start
+```
+
+The server listens on port `3000` by default and exposes a `POST`
+endpoint at `/api/exposure-rate`.
+

--- a/exposureRater.js
+++ b/exposureRater.js
@@ -44,7 +44,18 @@ function buildTable(rows){
 }
 
 function showError(msg){
-  // TODO insert alert component
+  const alert = document.createElement('div');
+  alert.textContent = msg;
+  alert.style.position = 'fixed';
+  alert.style.top = '1rem';
+  alert.style.right = '1rem';
+  alert.style.background = '#c0303b';
+  alert.style.color = '#fff';
+  alert.style.padding = '0.5rem 1rem';
+  alert.style.borderRadius = '4px';
+  alert.style.zIndex = 1000;
+  document.body.appendChild(alert);
+  setTimeout(() => alert.remove(), 3000);
 }
 
 export { renderTeams };

--- a/package.json
+++ b/package.json
@@ -1,10 +1,16 @@
 {
   "type": "module",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "start": "node server.js"
   },
   "devDependencies": {
     "jest": "^29.6.1",
     "jsdom": "^22.1.0"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "express-fileupload": "^1.4.0",
+    "csv-parse": "^5.5.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,51 @@
+import express from 'express';
+import fileUpload from 'express-fileupload';
+import { parse } from 'csv-parse/sync';
+
+const app = express();
+app.use(fileUpload());
+
+app.post('/api/exposure-rate', (req, res) => {
+  if (!req.files || !req.files.file) {
+    return res.status(400).json({ error: 'No file uploaded' });
+  }
+
+  const csvData = req.files.file.data.toString('utf8');
+  let records;
+  try {
+    records = parse(csvData, { columns: true, skip_empty_lines: true });
+  } catch (err) {
+    return res.status(400).json({ error: 'Invalid CSV' });
+  }
+
+  const teamsMap = new Map();
+  for (const row of records) {
+    const keys = Object.keys(row).reduce((acc, key) => {
+      acc[key.toLowerCase()] = key;
+      return acc;
+    }, {});
+    const teamKey = Object.keys(keys).find(k => k.includes('team'));
+    const ratingKey = Object.keys(keys).find(k => k.includes('rating'));
+
+    const name = teamKey ? row[keys[teamKey]] : 'Unknown';
+    const ratingVal = ratingKey ? parseFloat(row[keys[ratingKey]]) : NaN;
+    const rating = isNaN(ratingVal) ? 0 : ratingVal;
+
+    if (!teamsMap.has(name)) {
+      teamsMap.set(name, { name, rating: 0, roster: [] });
+    }
+    const team = teamsMap.get(name);
+    if (rating) {
+      team.rating = rating;
+    }
+    team.roster.push(row);
+  }
+
+  const teams = Array.from(teamsMap.values());
+  res.json(teams);
+});
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- implement Express server with `/api/exposure-rate`
- show toast error messages in `exposureRater.js`
- add server start script and dependencies
- document starting the server in README

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: 403 Forbidden to registry)*

------
https://chatgpt.com/codex/tasks/task_e_6849638ad5dc832eb8cba710d8cdb54a