### PR TITLE
Add browse buttons for CSV uploads

### DIFF
--- a/portfolio.css
+++ b/portfolio.css
@@ -60,6 +60,28 @@ label.upload-btn{
 }
 label.upload-btn:hover{background:var(--bb-blue-600);}
 
+/* File upload rows */
+.upload-row{
+  display:flex;
+  align-items:center;
+  gap:8px;
+  margin-bottom:12px;
+}
+label.browse-btn{
+  background:var(--bb-blue-500);
+  color:#fff;
+  display:inline-block;
+  padding:6px 12px;
+  border-radius:var(--radius);
+  font-weight:600;
+  cursor:pointer;
+  transition:var(--transition);
+}
+label.browse-btn:hover{background:var(--bb-blue-600);}
+.status{font-weight:600;}
+.status.success{color:green;}
+.status.error{color:red;}
+
 /* Create a responsive masonry-like grid for each draft card */
 #portfolio-wrapper{
   display:grid;

--- a/portfolio.html
+++ b/portfolio.html
@@ -25,16 +25,19 @@
       <h2>Select CSVs to Upload</h2>
       <div class="upload-row">
         <span>Pre-Draft (Underdog)</span>
+        <label for="pre-file" class="browse-btn">Browse</label>
         <input type="file" id="pre-file" accept=".csv">
         <span id="pre-status" class="status"></span>
       </div>
       <div class="upload-row">
         <span>Post-Draft (Underdog)</span>
+        <label for="post-file" class="browse-btn">Browse</label>
         <input type="file" id="post-file" accept=".csv">
         <span id="post-status" class="status"></span>
       </div>
       <div class="upload-row">
         <span>Eliminator</span>
+        <label for="elim-file" class="browse-btn">Browse</label>
         <input type="file" id="elim-file" accept=".csv">
         <span id="elim-status" class="status"></span>
       </div>


### PR DESCRIPTION
## Summary
- enable CSV selection in the portfolio modal by adding Browse buttons
- style upload rows, buttons, and status messages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a0d9dc858832e89998b5c2d63d425