### PR TITLE
Extend lineup card width

### DIFF
--- a/portfolio.css
+++ b/portfolio.css
@@ -90,7 +90,7 @@ label.browse-btn:hover{background:var(--bb-blue-600);}
 /* Display three lineup cards per row */
 #teams{
   display:grid;
-  grid-template-columns:repeat(3,minmax(408px,1fr));
+  grid-template-columns:repeat(3,minmax(450px,1fr));
   gap:40px;
   margin:56px auto;
   padding:0 32px;
@@ -136,6 +136,10 @@ label.browse-btn:hover{background:var(--bb-blue-600);}
 .player-table th,
 .player-table td{
   word-break:break-word;
+}
+.player-table th:nth-child(2),
+.player-table td:nth-child(2){
+  width:45%;
 }
 .player-table thead th{
   background:var(--bb-blue-500);


### PR DESCRIPTION
## Summary
- widen lineup cards and player name column for long names in post upload portfolio view

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a226d73b0832e888c1071ade90a8b