### PR TITLE
Center and widen lineup cards

### DIFF
--- a/portfolio.css
+++ b/portfolio.css
@@ -87,15 +87,16 @@ label.browse-btn:hover{background:var(--bb-blue-600);}
   display:block;
 }
 
-/* Display three lineup cards per row */
+/* Display lineup cards in a centered responsive grid */
 #teams{
   display:grid;
-  grid-template-columns:repeat(3,minmax(495px,1fr));
+  grid-template-columns:repeat(auto-fit,minmax(570px,1fr));
   gap:40px;
   margin:56px auto;
   padding:0 32px;
-  max-width:1440px;
+  max-width:1880px;
   align-items:start;
+  justify-content:center;
 }
 
 /* Draft card styling */


### PR DESCRIPTION
## Summary
- widen lineup cards in `portfolio.css` to 570px
- center the lineup card grid on the page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684abe343a9c832ea3d2822b9eb6f3f0