### PR TITLE
Revert Rate My Team page path

### DIFF
--- a/index.html
+++ b/index.html
@@ -122,42 +122,6 @@
       align-items: baseline;
       gap: 0.5rem;
     }
-    #hamburger-menu {
-      position: fixed;
-      top: 0;
-      left: 0;
-      margin: 0;
-      padding: 0.5rem;
-      z-index: 1000;
-    }
-    #menu-toggle {
-      background: none;
-      border: none;
-      font-size: 1.5rem;
-      cursor: pointer;
-      color: #1e90ff;
-    }
-    .menu-dropdown {
-      position: absolute;
-      top: calc(100% + 4px);
-      left: 0;
-      background: #fff;
-      border: 1px solid #ddd;
-      border-radius: 4px;
-      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-      display: none;
-      min-width: 120px;
-      z-index: 100;
-    }
-    .menu-dropdown a {
-      display: block;
-      padding: 0.5rem 0.75rem;
-      text-decoration: none;
-      color: #1e90ff;
-    }
-    .menu-dropdown a:hover {
-      background: #f5f5f5;
-    }
     .controls {
       display: flex;
       align-items: center;
@@ -302,7 +266,7 @@
       margin-top: -0.5rem;
       margin-bottom: 1rem;
     }
-    @media (max-width: 600px) {
+    @media (max-width: 640px) {
       #top-controls {
         flex-direction: column;
         align-items: stretch;
@@ -318,12 +282,6 @@
   <svg style="display:none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><symbol id="icon-download" viewBox="0 0 16 16"><path d="M8 1v9m0 0l-3-3m3 3l3-3M1 14h14" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></symbol></svg>
   <script src="config.js"></script>
   <header id="top-controls">
-    <div id="hamburger-menu">
-      <button id="menu-toggle" aria-label="Menu">&#9776;</button>
-      <div id="menu-dropdown" class="menu-dropdown">
-        <a href="portfolio.html" id="rateMyTeamLink">Rate My Team</a>
-      </div>
-    </div>
     <div id="title-container">
       <h1 id="page-title">Best Ball Rankings Builder</h1>
     </div>
@@ -1106,24 +1064,6 @@
     });
 
 
-    const menuToggle = document.getElementById('menu-toggle');
-    const menuDropdown = document.getElementById('menu-dropdown');
-    menuToggle.addEventListener('click', () => {
-      if (menuDropdown.style.display === 'block') {
-        menuDropdown.style.display = 'none';
-      } else {
-        menuDropdown.style.display = 'block';
-      }
-    });
-    document.addEventListener('click', e => {
-      if (
-        !menuDropdown.contains(e.target) &&
-        !menuToggle.contains(e.target)
-      ) {
-        menuDropdown.style.display = 'none';
-      }
-    });
-
     const dropZone = document.getElementById('drop-zone');
     const uploadInput = document.getElementById('upload-input');
     dropZone.addEventListener('click', () => uploadInput.click());
@@ -1138,18 +1078,12 @@
 
 
     const rateBtn = document.getElementById('rateMyTeamBtn');
-    const rateLink = document.getElementById('rateMyTeamLink');
     const hasSeen = localStorage.getItem('hasSeenRateMyTeam');
     if (rateBtn) {
       if (!hasSeen) rateBtn.classList.add('animate-pulse');
       rateBtn.addEventListener('click', () => {
         localStorage.setItem('hasSeenRateMyTeam', 'true');
         window.location.href = 'portfolio.html';
-      });
-    }
-    if (rateLink) {
-      rateLink.addEventListener('click', () => {
-        localStorage.setItem('hasSeenRateMyTeam', 'true');
       });
     }
 


### PR DESCRIPTION
## Summary
- retain prominent Rate My Team button next to Export
- remove newly created `/rate-my-team` page
- keep pulsing CTA that links to `portfolio.html`
- stack controls under sliders at 640px

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b60cb7fe8832eb2d3a37ddf1cf893