### PR TITLE
Limit pulse on rate button

### DIFF
--- a/index.html
+++ b/index.html
@@ -1102,6 +1102,8 @@
     const rateBtn = document.getElementById('rateMyTeamBtn');
     if (rateBtn) {
       rateBtn.classList.add('animate-pulse');
+      // Stop pulsing after 3 seconds
+      setTimeout(() => rateBtn.classList.remove('animate-pulse'), 3000);
       rateBtn.addEventListener('click', () => {
         window.location.href = 'portfolio.html';
       });


### PR DESCRIPTION
## Summary
- stop pulsing rate button after 3 seconds on page load

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684b67ceaaf0832eade3584fbfa72e48