### PR TITLE
Remove percent sign from total rating

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -166,7 +166,7 @@
         if(pct>=66) emojiArr=positiveEmojis;
         else if(pct<34) emojiArr=negativeEmojis;
         const colors=colorForPct(pct);
-        ratingEl.textContent=`${pct.toFixed(0)}%`;
+        ratingEl.textContent=`${pct.toFixed(0)}`;
         ratingEl.style.backgroundColor=colors.bg;
         ratingEl.style.color=colors.text;
         header.appendChild(ratingEl);


### PR DESCRIPTION
## Summary
- show the total rating value without the percent symbol on `portfolio.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b79629b00832e8345f1e7730d727f