### PR TITLE
Add Underdog icon to lineup cards

### DIFF
--- a/portfolio.css
+++ b/portfolio.css
@@ -117,6 +117,12 @@ label.browse-btn:hover{background:var(--bb-blue-600);}
   font-weight:700;
   min-height:48px;
 }
+.draft-card h2 img.icon{
+  width:1em;
+  height:1em;
+  margin-right:.4em;
+  vertical-align:middle;
+}
 .rating-pill{
   display:inline-block;
   margin-left:8px;

--- a/portfolio.html
+++ b/portfolio.html
@@ -156,9 +156,14 @@
         const card=document.createElement('div');
         card.className=`team-card draft-card roster-${team.rosterSize}`;
         const header=document.createElement('h2');
+        const icon=document.createElement('img');
+        icon.className='icon';
+        icon.src='https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRltuDZN3yIMK1sh9oDF7ykc7HYDeuCGoZ--g&s';
+        icon.alt='Underdog icon';
+        header.appendChild(icon);
         const feeDisp=parseFloat(team.entryFee).toString();
         const datePart=team.dateEntered?` - Date Entered: ${team.dateEntered}`:'';
-        header.textContent=`${team.tournamentTitle} - $${feeDisp}${datePart} - Total Rating: `;
+        header.append(`${team.tournamentTitle} - $${feeDisp}${datePart} - Total Rating: `);
         const ratingEl=document.createElement('span');
         ratingEl.className='rating-pill';
         const pct=Math.max(0,Math.min(100,((team.totalRating-7.5)/(11-7.5))*100));


### PR DESCRIPTION
## Summary
- add Underdog icon to each lineup card header
- style header icons for consistency

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b7ad9c298832ea3a8060d6bae5a10