### PR TITLE
Add team summary row

### DIFF
--- a/portfolio.css
+++ b/portfolio.css
@@ -145,6 +145,20 @@ label.browse-btn:hover{background:var(--bb-blue-600);}
   vertical-align:middle;
 }
 
+/* Team summary row */
+.team-summary{
+  display:flex;
+  flex-wrap:wrap;
+  align-items:center;
+  gap:8px;
+  margin-bottom:8px;
+}
+.team-count{
+  display:flex;
+  align-items:center;
+  font-weight:600;
+}
+
 /* Player tables */
 .player-table{
   width:100%;

--- a/portfolio.html
+++ b/portfolio.html
@@ -181,6 +181,32 @@
         emojiSpan.textContent=` ${em1}`;
         header.appendChild(emojiSpan);
         card.appendChild(header);
+
+        const summary=document.createElement('div');
+        summary.className='team-summary';
+        const counts={};
+        team.picks.forEach(p=>{
+          const code=teamMap[p["Team"]]||p["Team"]||'';
+          if(code) counts[code]=(counts[code]||0)+1;
+        });
+        Object.entries(counts).forEach(([code,count])=>{
+          if(count<2) return;
+          const item=document.createElement('div');
+          item.className='team-count';
+          const img=document.createElement('img');
+          img.src=`https://www.fantasynerds.com/images/nfl/team_logos/${code}.png`;
+          img.className='team-logo';
+          img.alt=code;
+          img.onerror=()=>{img.style.display='none';};
+          const span=document.createElement('span');
+          span.textContent=`${count}`;
+          item.appendChild(img);
+          item.appendChild(span);
+          summary.appendChild(item);
+        });
+        if(summary.childNodes.length){
+          card.appendChild(summary);
+        }
         const table=document.createElement('table');
           table.className="player-table";
         const thead=document.createElement('thead');


### PR DESCRIPTION
## Summary
- show a team summary row with logo and player count for teams that have 2+ players
- style new team summary row

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b7c741220832eb27980b5d6bb96c8