### PR TITLE
Move and hide upload prompt after upload

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -135,12 +135,15 @@
       if(uploadedFormats.elim) document.getElementById('chk-elim').checked=true;
       const uploadContainer=document.getElementById('upload-container');
       const uploadBtn=document.getElementById('open-modal');
+      const uploadTitle=uploadContainer.querySelector('h1');
       if(anyUploaded){
         uploadContainer.classList.add('uploaded');
         uploadBtn.textContent='Upload More';
+        if(uploadTitle) uploadTitle.style.display='none';
       }else{
         uploadContainer.classList.remove('uploaded');
         uploadBtn.textContent='Upload Exposure CSV';
+        if(uploadTitle) uploadTitle.style.display='block';
       }
     }
 


### PR DESCRIPTION
## Summary
- hide Upload Exposure CSV heading after files are uploaded
- keep the Upload More button fixed in top-right

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c2f78d460832e9e9236354977a73c