### PR TITLE
Fix spacing for format options section

### DIFF
--- a/portfolio.css
+++ b/portfolio.css
@@ -246,7 +246,7 @@ td[data-pos="TE"] .pos-dot{background:var(--te);}
 #format-options{
   display:none;
   text-align:center;
-  margin-top:0;
+  margin-top:50px;
 }
 #format-options p{
   margin:0 0 8px;


### PR DESCRIPTION
## Summary
- move the format filter section further down so it doesn't overlap the fixed upload button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c576ec63c832e8d124982378512b7