### PR TITLE
Add sort control to portfolio and tweak filter spacing

### DIFF
--- a/portfolio.css
+++ b/portfolio.css
@@ -264,7 +264,7 @@ td[data-pos="TE"] .pos-dot{background:var(--te);}
 #format-options{
   display:none;
   text-align:center;
-  margin:50px auto 0;
+  margin:30px auto 0;
 }
 #format-options p{
   margin:0 0 8px;
@@ -305,6 +305,22 @@ td[data-pos="TE"] .pos-dot{background:var(--te);}
   gap:6px;
 }
 #date-filter input[type="date"]{
+  padding:4px;
+  font-family:inherit;
+}
+
+#sort-control{
+  display:none;
+  font-weight:600;
+  align-self:flex-end;
+  margin-top:10px;
+}
+#sort-control label{
+  display:flex;
+  align-items:center;
+  gap:6px;
+}
+#sort-control select{
   padding:4px;
   font-family:inherit;
 }

--- a/portfolio.html
+++ b/portfolio.html
@@ -32,6 +32,14 @@
           <input type="date" id="end-date" min="2025-01-01">
         </label>
       </div>
+      <div id="sort-control" style="display:none;">
+        <label>Sort:
+          <select id="sort-order">
+            <option value="desc">Total Rating Descending</option>
+            <option value="asc">Total Rating Ascending</option>
+          </select>
+        </label>
+      </div>
     </div>
     <div id="teams"></div>
   </div>
@@ -164,9 +172,11 @@
       const postLabel=document.getElementById('label-post');
       const elimLabel=document.getElementById('label-elim');
       const dateFilter=document.getElementById('date-filter');
+      const sortControl=document.getElementById('sort-control');
       const anyUploaded=uploadedFormats.pre||uploadedFormats.post||uploadedFormats.elim;
       container.style.display=anyUploaded?'block':'none';
       if(dateFilter) dateFilter.style.display=anyUploaded?'block':'none';
+      if(sortControl) sortControl.style.display=anyUploaded?'block':'none';
       if(anyUploaded&&dateFilter){
         const startInput=document.getElementById('start-date');
         const endInput=document.getElementById('end-date');
@@ -248,10 +258,11 @@
       }
     }
 
-    function renderTeams(teams){
+    function renderTeams(teams,sortOrder){
       const teamsEl=document.getElementById('teams');
       teamsEl.innerHTML='';
-      teams.sort((a,b)=>b.totalRating-a.totalRating);
+      if(sortOrder==='asc') teams.sort((a,b)=>a.totalRating-b.totalRating);
+      else teams.sort((a,b)=>b.totalRating-a.totalRating);
       teams.forEach(team=>{
         const card=document.createElement('div');
         card.className=`team-card draft-card roster-${team.rosterSize}`;
@@ -350,7 +361,8 @@
         if(endDate&&t.draftDate&&t.draftDate>endDate) return false;
         return true;
       });
-      renderTeams(filtered);
+      const sortOrder=document.getElementById('sort-order').value;
+      renderTeams(filtered,sortOrder);
     }
 
     function standardizeTableHeights(){
@@ -420,6 +432,7 @@
     document.getElementById('chk-elim').addEventListener('change',filterAndRender);
     document.getElementById('start-date').addEventListener('change',filterAndRender);
     document.getElementById('end-date').addEventListener('change',filterAndRender);
+    document.getElementById('sort-order').addEventListener('change',filterAndRender);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose sort options in portfolio view
- tighten spacing for draft date filter
- allow choosing ascending or descending sort order

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c654df960832eb1602b20bed68e1a