### PR TITLE
Fix rating persistence in saved lineups

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -425,7 +425,7 @@
 
     loadUploads();
     updateFormatOptions();
-    filterAndRender();
+    ratingsPromise.then(filterAndRender);
 
     document.getElementById('chk-pre').addEventListener('change',filterAndRender);
     document.getElementById('chk-post').addEventListener('change',filterAndRender);


### PR DESCRIPTION
## Summary
- wait for rating data to load before rendering saved lineups

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c669c0818832eb1f4b40833533995