### PR TITLE
Fix portfolio controls layout

### DIFF
--- a/portfolio.css
+++ b/portfolio.css
@@ -80,9 +80,7 @@ button.upload-btn:hover{background:var(--bb-blue-600);}
 
 /* Compact upload button after CSVs uploaded */
 #upload-container.uploaded{
-  position:fixed;
-  top:20px;
-  left:20px;
+  position:static;
   margin:0;
   padding:0;
   background:none;
@@ -265,6 +263,7 @@ td[data-pos="TE"] .pos-dot{background:var(--te);}
   display:none;
   text-align:center;
   margin:0;
+  justify-self:center;
 }
 #format-options p{
   margin:0 0 8px;
@@ -287,18 +286,23 @@ td[data-pos="TE"] .pos-dot{background:var(--te);}
 
 /* Container for format checkboxes and date filter */
 #portfolio-controls{
-  display:flex;
-  flex-wrap:wrap;
-  align-items:center;
-  gap:16px;
+  display:block;
   margin-top:20px;
   padding:0 32px;
+}
+#portfolio-controls.with-uploads{
+  display:grid;
+  grid-template-columns:1fr 1fr 1fr;
+  grid-template-rows:auto auto;
+  align-items:start;
+  gap:16px;
 }
 
 #date-filter{
   display:none;
   font-weight:600;
   margin:0;
+  justify-self:end;
 }
 #date-filter label{
   display:flex;
@@ -314,6 +318,9 @@ td[data-pos="TE"] .pos-dot{background:var(--te);}
   display:none;
   font-weight:600;
   margin:0;
+  justify-self:end;
+  grid-column:3;
+  grid-row:2;
 }
 #sort-control label{
   display:flex;

--- a/portfolio.html
+++ b/portfolio.html
@@ -11,14 +11,14 @@
   <link rel="stylesheet" href="portfolio.css">
 </head>
 <body>
-  <div id="upload-container">
-    <h1>Upload Exposure CSV</h1>
-    <label id="open-modal" class="upload-btn">Upload Exposure CSV</label>
-    <button id="clear-lineups" class="upload-btn" style="display:none;">Clear Lineups</button>
-    <div id="message"></div>
-  </div>
   <div id="portfolio-wrapper">
     <div id="portfolio-controls">
+      <div id="upload-container">
+        <h1>Upload Exposure CSV</h1>
+        <label id="open-modal" class="upload-btn">Upload Exposure CSV</label>
+        <button id="clear-lineups" class="upload-btn" style="display:none;">Clear Lineups</button>
+        <div id="message"></div>
+      </div>
       <div id="format-options" style="display:none;">
         <p class="info-note">Showing Teams Drafted in the Following Formats:</p>
         <label id="label-pre" class="format-option"><img class="icon" src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcRltuDZN3yIMK1sh9oDF7ykc7HYDeuCGoZ--g&s" alt="Underdog logo"><input type="checkbox" id="chk-pre"> Pre-Draft</label>
@@ -206,6 +206,11 @@
         uploadBtn.textContent='Upload Exposure CSV';
         if(clearBtn) clearBtn.style.display='none';
         if(uploadTitle) uploadTitle.style.display='block';
+      }
+      const controls=document.getElementById('portfolio-controls');
+      if(controls){
+        if(anyUploaded) controls.classList.add('with-uploads');
+        else controls.classList.remove('with-uploads');
       }
     }
 


### PR DESCRIPTION
## Summary
- move upload container inside controls section
- lay out controls with CSS grid when uploads exist
- remove sticky positioning of upload controls

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c7d35e0d0832eaff61617a60ecd30