### PR TITLE
Swap sort dropdown for arrow

### DIFF
--- a/portfolio.css
+++ b/portfolio.css
@@ -327,7 +327,14 @@ td[data-pos="TE"] .pos-dot{background:var(--te);}
   align-items:center;
   gap:6px;
 }
-#sort-control select{
-  padding:4px;
+#sort-toggle{
+  padding:4px 8px;
   font-family:inherit;
+  background:var(--bb-blue-500);
+  color:#fff;
+  border:none;
+  border-radius:var(--radius);
+  cursor:pointer;
+  transition:var(--transition);
 }
+#sort-toggle:hover{background:var(--bb-blue-600);}

--- a/portfolio.html
+++ b/portfolio.html
@@ -33,11 +33,10 @@
         </label>
       </div>
       <div id="sort-control" style="display:none;">
-        <label>Sort:
-          <select id="sort-order">
-            <option value="desc">Total Rating Descending</option>
-            <option value="asc">Total Rating Ascending</option>
-          </select>
+        <label>Ratings Sort:
+          <button id="sort-toggle" aria-label="Toggle ratings sort">
+            &#8595;
+          </button>
         </label>
       </div>
     </div>
@@ -137,6 +136,7 @@
 
     const allTeams=[];
     const uploadedFormats={pre:false,post:false,elim:false};
+    let sortOrder='desc';
 
     function saveUploads(){
       try{
@@ -366,7 +366,6 @@
         if(endDate&&t.draftDate&&t.draftDate>endDate) return false;
         return true;
       });
-      const sortOrder=document.getElementById('sort-order').value;
       renderTeams(filtered,sortOrder);
     }
 
@@ -437,7 +436,11 @@
     document.getElementById('chk-elim').addEventListener('change',filterAndRender);
     document.getElementById('start-date').addEventListener('change',filterAndRender);
     document.getElementById('end-date').addEventListener('change',filterAndRender);
-    document.getElementById('sort-order').addEventListener('change',filterAndRender);
+    document.getElementById('sort-toggle').addEventListener('click',()=>{
+      sortOrder = sortOrder==='desc' ? 'asc' : 'desc';
+      document.getElementById('sort-toggle').innerHTML = sortOrder==='desc' ? '&#8595;' : '&#8593;';
+      filterAndRender();
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add new toggle button to sort lineups by rating
- handle click to flip arrow between ascending and descending
- style the new ratings sort button

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c7f835a40832eabfbecfc0ddb31f3