### PR TITLE
Adjust lineup card sizes

### DIFF
--- a/portfolio.css
+++ b/portfolio.css
@@ -121,8 +121,8 @@ label.browse-btn:hover{background:var(--bb-blue-600);}
 /* Display lineup cards in a centered responsive grid */
 #teams{
   display:grid;
-  grid-template-columns:repeat(auto-fit,minmax(570px,1fr));
-  gap:40px;
+  grid-template-columns:repeat(auto-fit,minmax(520px,1fr));
+  gap:32px;
   margin:56px auto;
   padding:0 32px;
   max-width:1880px;
@@ -131,22 +131,23 @@ label.browse-btn:hover{background:var(--bb-blue-600);}
 }
 
 /* Draft card styling */
+
 .draft-card{
   background:var(--bb-surface);
   border:2px solid var(--bb-blue-500);
   border-radius:var(--radius);
   box-shadow:var(--bb-shadow);
-  padding:24px 22px;
-  font-size:1.2em;
+  padding:20px 18px;
+  font-size:1.1em;
 
   overflow-x:auto;
 }
 .draft-card h2{
   margin:0 0 12px;
-  font-size:22px;
+  font-size:20px;
   color:var(--bb-blue-600);
   font-weight:700;
-  min-height:48px;
+  min-height:44px;
 }
 .draft-card h2 img.icon{
   width:0.6em;


### PR DESCRIPTION
## Summary
- update lineup grid sizing to use 520px columns
- tighten draft card padding and font sizes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c8c40cc7c832e93a3ee8f38bf655e