### PR TITLE
Restrict bar graph styling to Sentiment column

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,11 +41,9 @@
     tbody tr:hover {
       background-color: #f5f5f5;
     }
-    .bar-cell,
     .sentiment-cell {
       position: relative;
     }
-    .bar-cell::before,
     .sentiment-cell::before {
       content: '';
       position: absolute;
@@ -57,7 +55,6 @@
       border-radius: 4px;
       z-index: 0;
     }
-    .bar-cell span,
     .sentiment-cell span {
       position: relative;
       z-index: 1;
@@ -447,10 +444,8 @@
       },
       {
         header: '🏅 <span id="rankings-source">wmonighe</span> Rankings',
-        cell: r => {
-          const width = parseFloat(r.wmonighePct) * 100 || 0;
-          return `<td class="bar-cell" style="--width:${width}%"><span>${r.wmonigheRank}${r.wmonighePct ? ' (' + r.wmonighePct + ')' : ''}</span></td>`;
-        },
+        cell: r =>
+          `<td>${r.wmonigheRank}${r.wmonighePct ? ' (' + r.wmonighePct + ')' : ''}</td>`,
         sortKey: 'wmonigheRank',
       },
       {
@@ -464,8 +459,7 @@
           ) {
             text = 'Undrafted';
           }
-          const width = parseFloat(r.adpPct) * 100 || 0;
-          return `<td class="bar-cell" style="--width:${width}%"><span>${text}</span></td>`;
+          return `<td>${text}</td>`;
         },
         sortKey: 'adp',
       },
@@ -473,23 +467,20 @@
         header: '🏆 Fantasy Points',
         cell: r => {
           const pctText = r.fpPctDisplay || r.fpPct;
-          const width = parseFloat(r.fpPctValue !== undefined ? r.fpPctValue : r.fpPct) * 100 || 0;
-          return `<td class="bar-cell" style="--width:${width}%"><span>${r.fantasyPts}${pctText ? ' (' + pctText + ')' : ''}</span></td>`;
+          return `<td>${r.fantasyPts}${pctText ? ' (' + pctText + ')' : ''}</td>`;
         },
         sortKey: 'fantasyPts',
       },
       {
         header: '😊 Sentiment',
         cell: r =>
-          `<td class="bar-cell sentiment-cell" style="--width:${r.sentimentPercent}%"><span>${r.sentiment}${r.sentimentPct ? ' (' + r.sentimentPct + ')' : ''}</span></td>`,
+          `<td class="sentiment-cell" style="--width:${r.sentimentPercent}%"><span>${r.sentiment}${r.sentimentPct ? ' (' + r.sentimentPct + ')' : ''}</span></td>`,
         sortKey: 'sentimentValue',
       },
       {
         header: '🎲 Futures Props',
-        cell: r => {
-          const width = parseFloat(r.vorpPct) * 100 || 0;
-          return `<td class="bar-cell" style="--width:${width}%"><span>${r.vorp}${r.vorpPct ? ' (' + r.vorpPct + ')' : ''}</span></td>`;
-        },
+        cell: r =>
+          `<td>${r.vorp}${r.vorpPct ? ' (' + r.vorpPct + ')' : ''}</td>`,
         sortKey: 'vorp',
       },
     ];


### PR DESCRIPTION
## Summary
- remove bar graph styling from metric columns
- keep bar graph in Sentiment column only

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c910d9068832e8f7847d384fc8f9d