### PR TITLE
Adjust slider overflow behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -390,6 +390,7 @@
     }
 
     const prevWeights = {};
+    let lastChangedKey;
 
     let validateTimeout;
 
@@ -403,20 +404,23 @@
         (sum, k) => sum + (parseInt(weightInputs[k].value, 10) || 0),
         0
       );
-      if (total > 100) {
+
+      if (total > 100 && lastChangedKey) {
         alert('Total percentage cannot exceed 100%.');
-        Object.keys(weightInputs).forEach(k => {
-          weightInputs[k].value = prevWeights[k];
-          updateWeightDisplay(k);
-        });
-      } else {
-        Object.keys(weightInputs).forEach(k => {
-          prevWeights[k] = parseInt(weightInputs[k].value, 10) || 0;
-        });
+        const available = 100 - Object.keys(weightInputs).reduce((sum, k) => {
+          return sum + (k === lastChangedKey ? 0 : (parseInt(weightInputs[k].value, 10) || 0));
+        }, 0);
+        weightInputs[lastChangedKey].value = Math.max(0, available);
+        updateWeightDisplay(lastChangedKey);
       }
+
+      Object.keys(weightInputs).forEach(k => {
+        prevWeights[k] = parseInt(weightInputs[k].value, 10) || 0;
+      });
     }
 
     function handleWeightInput(key) {
+      lastChangedKey = key;
       updateWeightDisplay(key);
       scheduleValidation();
     }


### PR DESCRIPTION
## Summary
- avoid resetting sliders when total weight exceeds 100
- limit most recently changed slider to the remaining percentage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684df684b678832ea77a31836212072f