### PR TITLE
Update demo team on /rate page

### DIFF
--- a/rate/index.html
+++ b/rate/index.html
@@ -101,10 +101,26 @@
     const demoTeam = {
       name: 'Demo Team',
       players: {
-        QB: ['Patrick Mahomes'],
-        RB: ['Christian McCaffrey', 'Austin Ekeler'],
-        WR: ['Justin Jefferson', "Ja'Marr Chase", 'Cooper Kupp'],
-        TE: ['Travis Kelce']
+        QB: ['Patrick Mahomes', 'Jalen Hurts', 'Lamar Jackson'],
+        RB: [
+          'Christian McCaffrey',
+          'Austin Ekeler',
+          'Bijan Robinson',
+          'Saquon Barkley',
+          'Jonathan Taylor',
+          'Nick Chubb'
+        ],
+        WR: [
+          'Justin Jefferson',
+          "Ja'Marr Chase",
+          'Cooper Kupp',
+          'Tyreek Hill',
+          'Stefon Diggs',
+          'A.J. Brown',
+          'CeeDee Lamb',
+          'Davante Adams'
+        ],
+        TE: ['Travis Kelce', 'Mark Andrews']
       },
       yesVotes: 10,
       noVotes: 3


### PR DESCRIPTION
## Summary
- show a larger demo team on the `/rate` page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684dfe026be0832e8b7c0906b9d84c00