### PR TITLE
Add team logos to rate page

### DIFF
--- a/rate/index.html
+++ b/rate/index.html
@@ -8,10 +8,39 @@
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  <style>
+    .team-logo {
+      width: 30px;
+      height: 30px;
+      object-fit: contain;
+      margin-right: 8px;
+      vertical-align: middle;
+    }
+  </style>
 </head>
 <body class="bg-gray-100 p-4 min-h-screen flex items-center justify-center">
   <div id="app" class="max-w-4xl w-full"></div>
   <script type="text/babel">
+    const teamMap = { JAX: 'JAC' };
+    const playerTeamMap = {};
+
+    function canonicalName(name) {
+      return (name || '')
+        .toString()
+        .toLowerCase()
+        .replace(/[.'’]/g, '')
+        .replace(/[^a-z0-9]+/g, ' ')
+        .trim();
+    }
+
+    function getTeamLogo(player) {
+      const team = playerTeamMap[canonicalName(player)];
+      const code = teamMap[team] || team;
+      return team
+        ? `https://www.fantasynerds.com/images/nfl/team_logos/${code}.png`
+        : '';
+    }
+
     const TeamVotingCard = ({ team }) => {
       const { name, players } = team;
       const yesVotes = team.yesVotes || 0;
@@ -31,11 +60,17 @@
                 <span className="ml-2">: {players.QB.length}</span>
               </h3>
               <ul className="text-sm text-gray-900">
-                {players.QB.map((player, idx) => (
-                  <li key={`QB-${idx}`} className="mb-1 last:mb-0 border border-purple-300 rounded px-2 py-1">
-                    {player}
-                  </li>
-                ))}
+                {players.QB.map((player, idx) => {
+                  const logo = getTeamLogo(player);
+                  return (
+                    <li key={`QB-${idx}`} className="mb-1 last:mb-0 border border-purple-300 rounded px-2 py-1 flex items-center">
+                      {logo && (
+                        <img src={logo} className="team-logo" onError={e => (e.target.style.display = 'none')} />
+                      )}
+                      <span>{player}</span>
+                    </li>
+                  );
+                })}
               </ul>
             </div>
             {/* Running Back Group */}
@@ -45,11 +80,17 @@
                 <span className="ml-2">: {players.RB.length}</span>
               </h3>
               <ul className="text-sm text-gray-900">
-                {players.RB.map((player, idx) => (
-                  <li key={`RB-${idx}`} className="mb-1 last:mb-0 border border-green-300 rounded px-2 py-1">
-                    {player}
-                  </li>
-                ))}
+                {players.RB.map((player, idx) => {
+                  const logo = getTeamLogo(player);
+                  return (
+                    <li key={`RB-${idx}`} className="mb-1 last:mb-0 border border-green-300 rounded px-2 py-1 flex items-center">
+                      {logo && (
+                        <img src={logo} className="team-logo" onError={e => (e.target.style.display = 'none')} />
+                      )}
+                      <span>{player}</span>
+                    </li>
+                  );
+                })}
               </ul>
             </div>
             {/* Wide Receiver Group */}
@@ -59,11 +100,17 @@
                 <span className="ml-2">: {players.WR.length}</span>
               </h3>
               <ul className="text-sm text-gray-900">
-                {players.WR.map((player, idx) => (
-                  <li key={`WR-${idx}`} className="mb-1 last:mb-0 border border-amber-300 rounded px-2 py-1">
-                    {player}
-                  </li>
-                ))}
+                {players.WR.map((player, idx) => {
+                  const logo = getTeamLogo(player);
+                  return (
+                    <li key={`WR-${idx}`} className="mb-1 last:mb-0 border border-amber-300 rounded px-2 py-1 flex items-center">
+                      {logo && (
+                        <img src={logo} className="team-logo" onError={e => (e.target.style.display = 'none')} />
+                      )}
+                      <span>{player}</span>
+                    </li>
+                  );
+                })}
               </ul>
             </div>
             {/* Tight End Group */}
@@ -73,11 +120,17 @@
                 <span className="ml-2">: {players.TE.length}</span>
               </h3>
               <ul className="text-sm text-gray-900">
-                {players.TE.map((player, idx) => (
-                  <li key={`TE-${idx}`} className="mb-1 last:mb-0 border border-blue-300 rounded px-2 py-1">
-                    {player}
-                  </li>
-                ))}
+                {players.TE.map((player, idx) => {
+                  const logo = getTeamLogo(player);
+                  return (
+                    <li key={`TE-${idx}`} className="mb-1 last:mb-0 border border-blue-300 rounded px-2 py-1 flex items-center">
+                      {logo && (
+                        <img src={logo} className="team-logo" onError={e => (e.target.style.display = 'none')} />
+                      )}
+                      <span>{player}</span>
+                    </li>
+                  );
+                })}
               </ul>
             </div>
           </div>
@@ -97,6 +150,24 @@
         </div>
       );
     };
+
+    const sheetId = '1rNouBdE-HbWafu-shO_5JLPSrLhr-xuGpXYfyOI-2oY';
+    const rankingsUrl = `https://opensheet.elk.sh/${sheetId}/Rankings`;
+
+    async function loadTeams() {
+      try {
+        const rows = await fetch(rankingsUrl).then(res => res.json());
+        rows.forEach(r => {
+          const player = r.Player || r.player;
+          const team = r.Team || r.team;
+          if (player && team) {
+            playerTeamMap[canonicalName(player)] = team;
+          }
+        });
+      } catch (err) {
+        console.error('Error loading team data:', err);
+      }
+    }
 
     const demoTeam = {
       name: 'Demo Team',
@@ -127,7 +198,10 @@
     };
 
     const root = ReactDOM.createRoot(document.getElementById('app'));
-    root.render(<TeamVotingCard team={demoTeam} />);
+
+    loadTeams().then(() => {
+      root.render(<TeamVotingCard team={demoTeam} />);
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- fetch team info from the Rankings sheet
- show NFL team logos before each player name on /rate

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e02215a78832e91a4150f0388f4d3