### PR TITLE
Center yes/no buttons

### DIFF
--- a/rate/index.html
+++ b/rate/index.html
@@ -134,7 +134,7 @@
               </ul>
             </div>
           </div>
-          <div className="flex space-x-2 mt-4">
+          <div className="flex justify-center space-x-2 mt-4">
             <button className="flex items-center justify-center bg-green-600 text-white text-xs font-medium px-2 py-1 rounded hover:bg-green-700 active:bg-green-800 transition-colors duration-200">
               <span className="mr-1">👍</span>
               Yes


### PR DESCRIPTION
## Summary
- horizontally center Yes/No buttons in the voting widget

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e0bc2b020832eae88698715e270ce