### PR TITLE
Add React team rating components

### DIFF
--- a/src/__tests__/useStreak.test.ts
+++ b/src/__tests__/useStreak.test.ts
@@ -1,0 +1,20 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useStreak } from '../hooks/useStreak';
+
+describe('useStreak', () => {
+  it('increments streak once per day', () => {
+    const { result } = renderHook(() => useStreak());
+    act(() => {
+      const [, inc] = result.current;
+      inc();
+    });
+    const [state] = result.current;
+    expect(state.streak).toBe(1);
+    act(() => {
+      const [, inc] = result.current;
+      inc();
+    });
+    const [afterSecond] = result.current;
+    expect(afterSecond.streak).toBe(1);
+  });
+});

--- a/src/__tests__/useXP.test.ts
+++ b/src/__tests__/useXP.test.ts
@@ -1,0 +1,15 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useXP, XP_PER_RATING } from '../hooks/useXP';
+
+describe('useXP', () => {
+  it('increments level and xp correctly', () => {
+    const { result } = renderHook(() => useXP(95));
+    act(() => {
+      const [, addXP] = result.current;
+      addXP(XP_PER_RATING);
+    });
+    const [state] = result.current;
+    expect(state.level).toBe(1);
+    expect(state.xp).toBe(0);
+  });
+});

--- a/src/api/fetchNextTeam.ts
+++ b/src/api/fetchNextTeam.ts
@@ -1,0 +1,7 @@
+import { Team } from '../types';
+
+export async function fetchNextTeam(): Promise<Team> {
+  const res = await fetch('/api/nextTeam');
+  if (!res.ok) throw new Error('Failed to load next team');
+  return res.json();
+}

--- a/src/api/rateTeam.ts
+++ b/src/api/rateTeam.ts
@@ -1,0 +1,21 @@
+export interface RateRequest {
+  teamId: string;
+  rating: 'up' | 'down';
+}
+export interface Stats {
+  teamsRated: number;
+  xp: number;
+  level: number;
+  streak: number;
+  percentile: number;
+}
+
+export async function rateTeam(req: RateRequest): Promise<Stats> {
+  const res = await fetch('/api/rate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(req),
+  });
+  if (!res.ok) throw new Error('Failed to rate team');
+  return res.json();
+}

--- a/src/components/RatingOverlay.tsx
+++ b/src/components/RatingOverlay.tsx
@@ -1,0 +1,55 @@
+import { motion } from 'framer-motion';
+import { Stats } from '../api/rateTeam';
+import Confetti from 'react-confetti';
+import { useEffect, useState } from 'react';
+import { BADGES } from '../constants/gamification';
+
+interface Props {
+  stats: Stats;
+  onDismiss: () => void;
+}
+
+export const RatingOverlay = ({ stats, onDismiss }: Props) => {
+  const [showConfetti, setShowConfetti] = useState(false);
+  const badge = BADGES.find(b => b.threshold === stats.teamsRated);
+
+  useEffect(() => {
+    let timer = setTimeout(onDismiss, 1000);
+    if (badge) {
+      setShowConfetti(true);
+      timer = setTimeout(() => {
+        setShowConfetti(false);
+        onDismiss();
+      }, 1200);
+    }
+    return () => clearTimeout(timer);
+  }, [onDismiss, badge]);
+
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      className="absolute inset-0 bg-black/50 flex items-center justify-center z-20"
+    >
+      {showConfetti && <Confetti recycle={false} numberOfPieces={200} />}
+      <div className="bg-white rounded-lg p-4 shadow-lg text-center w-64">
+        <p className="font-semibold mb-2">Thanks for rating!</p>
+        <div className="text-sm space-y-1">
+          <p>Teams Rated: {stats.teamsRated}</p>
+          <p>Streak: {stats.streak} 🔥</p>
+          <div className="w-full bg-gray-200 rounded h-2 overflow-hidden">
+            <motion.div
+              className="bg-green-500 h-2"
+              initial={{ width: 0 }}
+              animate={{ width: `${(stats.xp / 100) * 100}%` }}
+            />
+          </div>
+          <p>Level {stats.level}</p>
+          <p>Top {stats.percentile}% today</p>
+        </div>
+        {badge && <p className="mt-2 font-bold">Unlocked: {badge.name}</p>}
+      </div>
+    </motion.div>
+  );
+};

--- a/src/components/TeamRater.tsx
+++ b/src/components/TeamRater.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react';
+import { Team } from '../types';
+import { fetchNextTeam } from '../api/fetchNextTeam';
+import { rateTeam, Stats } from '../api/rateTeam';
+import { useXP, XP_PER_RATING } from '../hooks/useXP';
+import { useStreak } from '../hooks/useStreak';
+import { RatingOverlay } from './RatingOverlay';
+import { motion, AnimatePresence } from 'framer-motion';
+import { toast } from 'react-toastify';
+
+interface Props {
+  initialTeam: Team;
+  initialStats: Stats;
+}
+
+export const TeamRater = ({ initialTeam, initialStats }: Props) => {
+  const [team, setTeam] = useState<Team>(initialTeam);
+  const [nextTeam, setNextTeam] = useState<Team | null>(null);
+  const [overlayStats, setOverlayStats] = useState<Stats | null>(null);
+
+  const [xpState, addXP] = useXP(initialStats.xp);
+  const [streakState, incStreak] = useStreak({ streak: initialStats.streak, lastDate: null });
+
+  useEffect(() => {
+    fetchNextTeam().then(setNextTeam).catch(() => {});
+  }, []);
+
+  const handleVote = async (rating: 'up' | 'down') => {
+    try {
+      const updated = await rateTeam({ teamId: team.id, rating });
+      addXP(XP_PER_RATING);
+      incStreak();
+      setOverlayStats(updated);
+      if (nextTeam) {
+        setTeam(nextTeam);
+        fetchNextTeam().then(setNextTeam).catch(() => {});
+      }
+      toast.success('Rating submitted');
+    } catch (err) {
+      toast.error('Error submitting rating');
+    }
+  };
+
+  return (
+    <div className="relative w-full max-w-lg mx-auto">
+      <AnimatePresence>
+        {overlayStats && (
+          <RatingOverlay stats={overlayStats} onDismiss={() => setOverlayStats(null)} />
+        )}
+      </AnimatePresence>
+      <div className="overflow-hidden h-96 relative">
+        <AnimatePresence initial={false} custom={team.id}>
+          <motion.div
+            key={team.id}
+            initial={{ x: 300, opacity: 0 }}
+            animate={{ x: 0, opacity: 1 }}
+            exit={{ x: -300, opacity: 0 }}
+            transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+            className="absolute inset-0"
+          >
+            {/* Render team info */}
+            <div className="bg-white rounded-lg shadow p-4 h-full flex flex-col">
+              <h2 className="text-xl font-bold mb-2 text-center">{team.name}</h2>
+              <div className="flex-1 overflow-y-auto text-sm grid grid-cols-2 gap-2">
+                {(['QB','RB','WR','TE'] as const).map(pos => (
+                  <div key={pos}>
+                    <p className="font-semibold mb-1">{pos}</p>
+                    <ul className="space-y-1">
+                      {team.players[pos].map(p => (
+                        <li key={p} className="border rounded px-1">{p}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </div>
+              <div className="flex justify-around mt-4">
+                <button
+                  onClick={() => handleVote('up')}
+                  className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded"
+                >
+                  👍
+                </button>
+                <button
+                  onClick={() => handleVote('down')}
+                  className="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded"
+                >
+                  👎
+                </button>
+              </div>
+            </div>
+          </motion.div>
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+};

--- a/src/constants/gamification.ts
+++ b/src/constants/gamification.ts
@@ -1,0 +1,10 @@
+export const BADGES = [
+  { threshold: 50, name: 'Rookie Rater' },
+  { threshold: 100, name: 'Seasoned Scouter' },
+  { threshold: 500, name: 'Hall of Fame' },
+];
+
+export const LEVEL_THRESHOLDS = [
+  { level: 1, xp: 0 },
+  { level: 5, xp: 500 },
+];

--- a/src/hooks/usePercentile.ts
+++ b/src/hooks/usePercentile.ts
@@ -1,0 +1,7 @@
+import { useState } from 'react';
+
+export function usePercentile(initial = 0): [number, (p: number) => void] {
+  const [percentile, setPercentile] = useState(initial);
+  const update = (p: number) => setPercentile(p);
+  return [percentile, update];
+}

--- a/src/hooks/useStreak.ts
+++ b/src/hooks/useStreak.ts
@@ -1,0 +1,21 @@
+import { useState } from 'react';
+
+export interface StreakState {
+  streak: number;
+  lastDate: string | null;
+}
+
+export function useStreak(initial: StreakState = { streak: 0, lastDate: null }): [StreakState, () => void] {
+  const [state, setState] = useState<StreakState>(initial);
+
+  const increment = () => {
+    const today = new Date().toDateString();
+    setState(prev => {
+      if (prev.lastDate === today) return prev;
+      const nextStreak = prev.lastDate ? prev.streak + 1 : 1;
+      return { streak: nextStreak, lastDate: today };
+    });
+  };
+
+  return [state, increment];
+}

--- a/src/hooks/useXP.ts
+++ b/src/hooks/useXP.ts
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+
+export interface XPState {
+  xp: number;
+  level: number;
+}
+
+/** XP per rating and points to next level */
+export const XP_PER_RATING = 5;
+export const LEVEL_XP = 100;
+
+export function useXP(initialXP = 0): [XPState, (points: number) => void] {
+  const [state, setState] = useState<XPState>({
+    xp: initialXP % LEVEL_XP,
+    level: Math.floor(initialXP / LEVEL_XP),
+  });
+
+  const addXP = (points: number) => {
+    setState(prev => {
+      const total = prev.xp + points;
+      const levelGain = Math.floor(total / LEVEL_XP);
+      return {
+        xp: total % LEVEL_XP,
+        level: prev.level + levelGain,
+      };
+    });
+  };
+
+  return [state, addXP];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,12 @@
+export interface Team {
+  id: string;
+  name: string;
+  players: {
+    QB: string[];
+    RB: string[];
+    WR: string[];
+    TE: string[];
+  };
+  yesVotes?: number;
+  noVotes?: number;
+}


### PR DESCRIPTION
## Summary
- add gamification hooks with XP, streak, and percentile helpers
- implement API helpers for rating flow
- add `RatingOverlay` and `TeamRater` components with framer-motion animations
- include badge and level constants
- provide jest unit tests for hooks

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e118f5ed4832e98600368e9d878cf