### PR TITLE
Update demo rosters on /rate

### DIFF
--- a/rate/index.html
+++ b/rate/index.html
@@ -177,10 +177,9 @@
           RB: [
             'Christian McCaffrey',
             'Austin Ekeler',
-            'Bijan Robinson',
             'Saquon Barkley',
-            'Jonathan Taylor',
-            'Nick Chubb'
+            'Nick Chubb',
+            'Bijan Robinson'
           ],
           WR: [
             'Justin Jefferson',
@@ -200,10 +199,24 @@
       {
         name: 'Team A',
         players: {
-          QB: ['Josh Allen', 'Tua Tagovailoa'],
-          RB: ['Derrick Henry', 'Dalvin Cook'],
-          WR: ["Ja'Marr Chase", 'Stefon Diggs', 'Tyreek Hill'],
-          TE: ['George Kittle']
+          QB: ['Josh Allen', 'Tua Tagovailoa', 'Justin Fields'],
+          RB: [
+            'Derrick Henry',
+            'Dalvin Cook',
+            'Aaron Jones',
+            'Najee Harris',
+            'Josh Jacobs',
+            'Breece Hall'
+          ],
+          WR: [
+            "Ja'Marr Chase",
+            'Stefon Diggs',
+            'Tyreek Hill',
+            'DeAndre Hopkins',
+            'Keenan Allen',
+            'Terry McLaurin'
+          ],
+          TE: ['George Kittle', 'Kyle Pitts', 'Dallas Goedert']
         },
         yesVotes: 5,
         noVotes: 2
@@ -211,10 +224,24 @@
       {
         name: 'Team B',
         players: {
-          QB: ['Joe Burrow', 'Justin Herbert'],
-          RB: ['Alvin Kamara', 'Tony Pollard'],
-          WR: ['DK Metcalf', 'CeeDee Lamb', 'A.J. Brown'],
-          TE: ['Darren Waller']
+          QB: ['Joe Burrow', 'Justin Herbert', 'Kirk Cousins'],
+          RB: [
+            'Alvin Kamara',
+            'Tony Pollard',
+            'Javonte Williams',
+            'James Cook',
+            'Rhamondre Stevenson',
+            'J.K. Dobbins'
+          ],
+          WR: [
+            'DK Metcalf',
+            'CeeDee Lamb',
+            'A.J. Brown',
+            'Garrett Wilson',
+            'Jaylen Waddle',
+            'Chris Olave'
+          ],
+          TE: ['Darren Waller', 'T.J. Hockenson', 'Pat Freiermuth']
         },
         yesVotes: 2,
         noVotes: 6


### PR DESCRIPTION
## Summary
- bring all demo teams on /rate in line with lineup limits

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ef39e9f10832eb99af84692dde1b5