### PR TITLE
Add Supabase setup for all pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,5 +12,7 @@
     <li><a href="rate/">Rate Teams</a></li>
     <li><a href="portfolio.html">Portfolio</a></li>
   </ul>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+  <script src="supabase.js"></script>
 </body>
 </html>

--- a/portfolio.html
+++ b/portfolio.html
@@ -67,6 +67,8 @@
       <button id="upload-done">Done</button>
     </div>
   </div>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+  <script src="supabase.js"></script>
 
   <script>
     const requiredHeaders = [

--- a/rank.html
+++ b/rank.html
@@ -282,6 +282,8 @@
 <body>
   <svg style="display:none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><symbol id="icon-download" viewBox="0 0 16 16"><path d="M8 1v9m0 0l-3-3m3 3l3-3M1 14h14" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></symbol></svg>
   <script src="config.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+  <script src="supabase.js"></script>
   <header id="top-controls">
     <div id="title-container">
       <button type="button" class="btn btn-primary" id="rateMyTeamBtn" aria-label="Rate my fantasy teams">Rate My Teams</button>

--- a/rate/index.html
+++ b/rate/index.html
@@ -21,6 +21,8 @@
 <body class="bg-gray-100 p-4 min-h-screen flex items-center justify-center">
   <div id="app" class="max-w-4xl w-full"></div>
   <div id="toast" class="hidden fixed bottom-4 left-1/2 transform -translate-x-1/2 bg-gray-800 text-white px-4 py-2 rounded shadow-lg transition-opacity"></div>
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
+  <script src="../supabase.js"></script>
   <script type="text/babel">
     const teamMap = { JAX: 'JAC' };
     const playerTeamMap = {};

--- a/supabase.js
+++ b/supabase.js
@@ -1,0 +1,5 @@
+const SUPABASE_URL = 'YOUR_PROJECT_URL';
+const SUPABASE_ANON_KEY = 'YOUR_PUBLIC_ANON_KEY';
+
+const supabase = supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+


### PR DESCRIPTION
## Summary
- initialize supabase client in `supabase.js`
- load Supabase on every HTML page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6850a362036c832e99f0cb1a0d92ba52