### PR TITLE
Fix quoting for existing row check

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -275,7 +275,7 @@
             const {data:existing,error:selectErr}=await supabase
               .from('underdog_draft_upload')
               .select('"Draft Entry"')
-              .in('Draft Entry',entryIds);
+              .in('"Draft Entry"',entryIds);
             if(selectErr){
               console.error('Supabase fetch error',selectErr);
             }else if(existing){


### PR DESCRIPTION
## Summary
- fix Supabase `.in()` column quoting in `uploadRowsToSupabase`

## Testing
- `node /tmp/supabase_test.js` *(fails: Cannot find module 'node-fetch')*

------
https://chatgpt.com/codex/tasks/task_e_68520e9301ec832e9f97d5c2e292ec38