### PR TITLE
Adjust lineups per page to 20

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -175,7 +175,7 @@
     let sortOrder='desc';
     let uploading=false;
     let currentPage=1;
-    const pageSize=100;
+    const pageSize=20;
     let filteredTeams=[];
 
     function saveUploads(){


### PR DESCRIPTION
## Summary
- update `portfolio.html` to display 20 lineups per page instead of 100

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853400516c0832eabee7d3b5581744b