### PR TITLE
Add lineup share feature

### DIFF
--- a/portfolio.css
+++ b/portfolio.css
@@ -173,6 +173,7 @@ label.browse-btn:hover{background:var(--bb-blue-600);}
   box-shadow:var(--bb-shadow);
   padding:6px;
   font-size:.79em;
+  position:relative;
 
   overflow-x:auto;
 }
@@ -201,6 +202,43 @@ label.browse-btn:hover{background:var(--bb-blue-600);}
   margin-left:6px;
   font-size:14px;
 }
+
+/* Share button on lineup cards */
+.share-btn{
+  position:absolute;
+  top:4px;
+  right:4px;
+  background:var(--bb-blue-500);
+  color:#fff;
+  border:none;
+  border-radius:var(--radius);
+  padding:2px 6px;
+  font-size:11px;
+  cursor:pointer;
+}
+.share-btn:hover{background:var(--bb-blue-600);}
+
+/* Message included in share preview */
+.share-message{
+  margin-top:8px;
+  font-weight:600;
+  text-align:center;
+}
+.share-message a{
+  color:var(--bb-blue-600);
+  text-decoration:none;
+  font-weight:700;
+}
+
+#share-link{
+  width:100%;
+  margin-top:8px;
+  padding:6px;
+  font-size:14px;
+  font-family:inherit;
+}
+
+#copy-link{margin-top:8px;}
 
 /* Team logos */
 .team-logo{

--- a/portfolio.html
+++ b/portfolio.html
@@ -104,8 +104,18 @@
       <button id="query-done">Done</button>
     </div>
   </div>
+  <div id="share-modal" class="modal">
+    <div class="modal-content">
+      <h2>Share Lineup</h2>
+      <img id="share-image" alt="Share preview" style="max-width:100%;height:auto;">
+      <input id="share-link" type="text" readonly>
+      <button id="copy-link">Copy Link</button>
+      <button id="share-close">Close</button>
+    </div>
+  </div>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
   <script src="supabase.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 
   <script>
     const requiredHeaders = [
@@ -473,6 +483,11 @@
         const em1=pickEmoji(emojiArr);
         emojiSpan.textContent=` ${em1}`;
         header.appendChild(emojiSpan);
+        const shareBtn=document.createElement('button');
+        shareBtn.className='share-btn';
+        shareBtn.textContent='Share';
+        shareBtn.addEventListener('click',()=>openShareModal(team,card));
+        card.appendChild(shareBtn);
         card.appendChild(header);
 
         const summary=document.createElement('div');
@@ -684,6 +699,21 @@
       });
     }
 
+    function openShareModal(team,card){
+      const pct=Math.max(0,Math.min(100,((team.totalRating-7.5)/(11-7.5))*100)).toFixed(0);
+      const clone=card.cloneNode(true);
+      const msg=document.createElement('div');
+      msg.className='share-message';
+      msg.innerHTML=`My lineup scored ${pct}. How do your teams compare? <a href="portfolio.html">See now.</a>`;
+      clone.appendChild(msg);
+      clone.style.width=card.offsetWidth+'px';
+      html2canvas(clone).then(canvas=>{
+        document.getElementById('share-image').src=canvas.toDataURL();
+        document.getElementById('share-link').value=location.origin+'/portfolio.html';
+        document.getElementById('share-modal').classList.add('show');
+      });
+    }
+
     document.getElementById('open-modal').addEventListener('click',()=>{
       document.getElementById('upload-modal').classList.add('show');
       if(insertCountEl) insertCountEl.textContent='';
@@ -705,6 +735,14 @@
 
     document.getElementById('query-done').addEventListener('click',()=>{
       document.getElementById('query-modal').classList.remove('show');
+    });
+
+    document.getElementById('share-close').addEventListener('click',()=>{
+      document.getElementById('share-modal').classList.remove('show');
+    });
+    document.getElementById('copy-link').addEventListener('click',()=>{
+      const val=document.getElementById('share-link').value;
+      navigator.clipboard.writeText(val);
     });
 
     document.getElementById('pre-file').addEventListener('change',async e=>{


### PR DESCRIPTION
## Summary
- allow lineup cards on `portfolio.html` to be shared
- include share button styling in `portfolio.css`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68548de4bf8c832e8ebdd3715ee3d6e4