### PR TITLE
Fix share screenshot when images blocked

### DIFF
--- a/portfolio.css
+++ b/portfolio.css
@@ -248,6 +248,18 @@ label.browse-btn:hover{background:var(--bb-blue-600);}
   margin-right:8px;
   vertical-align:middle;
 }
+/* Fallback abbreviation shown when team logo cannot be loaded */
+.team-abbr{
+  display:inline-block;
+  width:16px;
+  height:16px;
+  line-height:16px;
+  margin-right:8px;
+  text-align:center;
+  font-size:10px;
+  font-weight:600;
+  vertical-align:middle;
+}
 
 /* Team summary row */
 .team-summary{

--- a/portfolio.html
+++ b/portfolio.html
@@ -707,10 +707,22 @@
       msg.innerHTML=`My lineup scored ${pct}. How do your teams compare? <a href="portfolio.html">See now.</a>`;
       clone.appendChild(msg);
       clone.style.width=card.offsetWidth+'px';
-      html2canvas(clone,{useCORS:true}).then(canvas=>{
+      const showModal=canvas=>{
         document.getElementById('share-image').src=canvas.toDataURL();
         document.getElementById('share-link').value=location.origin+'/portfolio.html';
         document.getElementById('share-modal').classList.add('show');
+      };
+
+      html2canvas(clone,{useCORS:true}).then(showModal).catch(()=>{
+        clone.querySelectorAll('img.team-logo').forEach(img=>{
+          const abbr=(img.alt||'').slice(0,3).toUpperCase();
+          const span=document.createElement('span');
+          span.className='team-abbr';
+          span.textContent=abbr;
+          img.replaceWith(span);
+        });
+        clone.querySelectorAll('img').forEach(img=>img.remove());
+        html2canvas(clone).then(showModal);
       });
     }
 


### PR DESCRIPTION
## Summary
- add fallback CSS for team abbreviation
- handle html2canvas errors by swapping images for 3-letter team abbreviations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685495cc2000832ea38438506bdaa73d