### PR TITLE
Fix overlap of sort and view controls

### DIFF
--- a/portfolio.css
+++ b/portfolio.css
@@ -430,7 +430,7 @@ td[data-pos="TE"] .pos-dot{background:var(--te);}
   font-weight:600;
   margin:0;
   justify-self:end;
-  grid-column:3;
+  grid-column:2;
   grid-row:2;
 }
 #view-control label{


### PR DESCRIPTION
## Summary
- ensure view mode toggle has its own grid column so it doesn't overlap ratings sort

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6854a0b890f4832eb05d418141c70272