### PR TITLE
Update nav links and init auth script

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -18,8 +18,8 @@
       <a href="/portfolio">Team Rater</a>
     </div>
     <div class="nav-right">
-      <a href="#">Sign Up</a>
-      <a href="#">Login</a>
+      <a href="auth.html?mode=signup">Sign Up</a>
+      <a href="auth.html?mode=login">Login</a>
     </div>
   </nav>
   <div id="portfolio-wrapper">
@@ -133,6 +133,10 @@
   </div>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
   <script src="supabase.js"></script>
+  <script type="module">
+    import { init } from './auth.js';
+    init();
+  </script>
   <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 
   <script>

--- a/rank.html
+++ b/rank.html
@@ -286,14 +286,18 @@
       <a href="/portfolio">Team Rater</a>
     </div>
     <div class="nav-right">
-      <a href="#">Sign Up</a>
-      <a href="#">Login</a>
+      <a href="auth.html?mode=signup">Sign Up</a>
+      <a href="auth.html?mode=login">Login</a>
     </div>
   </nav>
   <svg style="display:none" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16"><symbol id="icon-download" viewBox="0 0 16 16"><path d="M8 1v9m0 0l-3-3m3 3l3-3M1 14h14" stroke="currentColor" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round"/></symbol></svg>
   <script src="config.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js"></script>
   <script src="supabase.js"></script>
+  <script type="module">
+    import { init } from './auth.js';
+    init();
+  </script>
   <header id="top-controls">
     <div id="title-container">
       <button type="button" class="btn btn-primary" id="rateMyTeamBtn" aria-label="Rate my fantasy teams">Rate My Teams</button>


### PR DESCRIPTION
## Summary
- link sign up/login buttons to `auth.html`
- run `init()` from `auth.js` after loading `supabase.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6855e88f1b38832e94f7d0e1d030d62f