### PR TITLE
Add Supabase user creation on login

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -949,10 +949,12 @@
 
     window.supabase.auth.onAuthStateChange((_event, session) => {
       updateAuthUI(session?.user);
+      if (session?.user) window.ensureUserRow(session.user);
     });
 
     window.supabase.auth.getSession().then(({ data }) => {
       updateAuthUI(data.session?.user);
+      if (data.session?.user) window.ensureUserRow(data.session.user);
     });
 
     initExposureDrawer();

--- a/rank.html
+++ b/rank.html
@@ -1136,10 +1136,12 @@
 
     window.supabase.auth.onAuthStateChange((_event, session) => {
       updateAuthUI(session?.user);
+      if (session?.user) window.ensureUserRow(session.user);
     });
 
     window.supabase.auth.getSession().then(({ data }) => {
       updateAuthUI(data.session?.user);
+      if (data.session?.user) window.ensureUserRow(data.session.user);
     });
 
 

--- a/supabase.js
+++ b/supabase.js
@@ -8,3 +8,27 @@ window.supabase = window.supabase.createClient(
   SUPABASE_ANON_KEY
 );
 
+// Insert the authenticated user into the Users table if they don't exist yet
+// Exposed globally so any page can call it after login
+window.ensureUserRow = async function(user) {
+  if (!user) return;
+  const { data, error } = await window.supabase
+    .from('Users')
+    .select('id')
+    .eq('id', user.id)
+    .maybeSingle();
+  if (error) {
+    console.error('Error checking user row', error);
+    return;
+  }
+  if (!data) {
+    const { error: insertErr } = await window.supabase.from('Users').insert({
+      id: user.id,
+      email: user.email,
+      username: '',
+      date_created: new Date().toISOString()
+    });
+    if (insertErr) console.error('Error inserting user row', insertErr);
+  }
+};
+


### PR DESCRIPTION
## Summary
- add helper in `supabase.js` to insert a user into the `Users` table the first time they log in
- call helper after authentication state changes in `rank.html` and `portfolio.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685610acd6bc832e9927581b9ff5691c