### PR TITLE
Fix draft ID lookup to use latest season

### DIFF
--- a/rank.html
+++ b/rank.html
@@ -1071,10 +1071,17 @@
         draftIdMap = {};
         data.forEach(r => {
           const canon = canonicalName(r.player);
-          draftIdMap[canon] = r;
-          const altCanon = altCanonicalName(r.player);
-          if (!draftIdMap[altCanon]) {
-            draftIdMap[altCanon] = r;
+          const existing = draftIdMap[canon];
+          if (!existing || parseInt(r.season, 10) > parseInt(existing.season, 10)) {
+            draftIdMap[canon] = r;
+          }
+        });
+        // Add alt canonical names after determining the latest season record
+        Object.values(draftIdMap).forEach(rec => {
+          const altCanon = altCanonicalName(rec.player);
+          const existing = draftIdMap[altCanon];
+          if (!existing || parseInt(rec.season, 10) > parseInt(existing.season, 10)) {
+            draftIdMap[altCanon] = rec;
           }
         });
         return draftIdMap;


### PR DESCRIPTION
## Summary
- pick the latest season record when loading `player_draft_ids`
- ensure aliases for alternate canonical names point to that record

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68573ee85838832ea18a74158289e126