### PR TITLE
Fix Pre-Draft label in portfolio upload modal

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -90,7 +90,7 @@
     <div class="modal-content">
       <h2>Select CSVs to Upload</h2>
       <div class="upload-row">
-        <span>Post-Draft (Underdog)</span>
+        <span>Pre-Draft (Underdog)</span>
         <label for="pre-file" class="browse-btn">Browse</label>
         <input type="file" id="pre-file" accept=".csv">
         <progress id="pre-progress" max="100" value="0" class="upload-progress" style="display:none;"></progress>


### PR DESCRIPTION
## Summary
- correct the first upload row label in `portfolio.html` so that it's **Pre-Draft (Underdog)** instead of **Post-Draft (Underdog)**

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68574ca38e3c832eabb0d7532c114a7f