### PR TITLE
Increase lineup card size

### DIFF
--- a/portfolio.css
+++ b/portfolio.css
@@ -154,7 +154,8 @@ label.browse-btn:hover{background:var(--bb-blue-600);}
 /* Display lineup cards in a centered responsive grid */
 #teams{
   display:grid;
-  grid-template-columns:repeat(auto-fit,minmax(352px,1fr));
+  /* Increased width for larger lineup cards */
+  grid-template-columns:repeat(auto-fit,minmax(388px,1fr));
   gap:12px;
   margin:20px auto;
   padding:0 20px;
@@ -176,7 +177,8 @@ label.browse-btn:hover{background:var(--bb-blue-600);}
   border-radius:var(--radius);
   box-shadow:var(--bb-shadow);
   padding:6px;
-  font-size:.79em;
+  /* Slightly larger overall font size */
+  font-size:.87em;
   position:relative;
 
   overflow-x:auto;


### PR DESCRIPTION
## Summary
- adjust lineup card width to 388px minimum
- increase draft card font size for better readability

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68574d2402f0832eaeb588ebc34d18f8