### PR TITLE
Handle OAuth redirect session

### DIFF
--- a/portfolio.html
+++ b/portfolio.html
@@ -956,10 +956,21 @@
       if (session?.user) window.ensureUserRow(session.user);
     });
 
-    window.supabase.auth.getSession().then(({ data }) => {
-      updateAuthUI(data.session?.user);
-      if (data.session?.user) window.ensureUserRow(data.session.user);
-    });
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get('code')) {
+      window.supabase.auth.exchangeCodeForSession(window.location.href)
+        .then(({ data, error }) => {
+          if (error) console.error('Error exchanging code', error);
+          history.replaceState({}, document.title, window.location.pathname);
+          updateAuthUI(data?.user);
+          if (data?.user) window.ensureUserRow(data.user);
+        });
+    } else {
+      window.supabase.auth.getSession().then(({ data }) => {
+        updateAuthUI(data.session?.user);
+        if (data.session?.user) window.ensureUserRow(data.session.user);
+      });
+    }
 
     initExposureDrawer();
   </script>

--- a/rank.html
+++ b/rank.html
@@ -1249,10 +1249,21 @@
       if (session?.user) window.ensureUserRow(session.user);
     });
 
-    window.supabase.auth.getSession().then(({ data }) => {
-      updateAuthUI(data.session?.user);
-      if (data.session?.user) window.ensureUserRow(data.session.user);
-    });
+    const urlParams = new URLSearchParams(window.location.search);
+    if (urlParams.get('code')) {
+      window.supabase.auth.exchangeCodeForSession(window.location.href)
+        .then(({ data, error }) => {
+          if (error) console.error('Error exchanging code', error);
+          history.replaceState({}, document.title, window.location.pathname);
+          updateAuthUI(data?.user);
+          if (data?.user) window.ensureUserRow(data.user);
+        });
+    } else {
+      window.supabase.auth.getSession().then(({ data }) => {
+        updateAuthUI(data.session?.user);
+        if (data.session?.user) window.ensureUserRow(data.session.user);
+      });
+    }
 
 
     showSkeleton();


### PR DESCRIPTION
## Summary
- establish session after OAuth redirect on rank and portfolio pages
- clean URL query params after exchange

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b2d621c84832ea4f376006bd526cc